### PR TITLE
Remove spark dependency from hive client - Fixes #7

### DIFF
--- a/aws-glue-datacatalog-hive2-client/pom.xml
+++ b/aws-glue-datacatalog-hive2-client/pom.xml
@@ -65,14 +65,6 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- jar for unit/integration tests -->
-        <dependency>
-            <groupId>com.amazonaws.glue</groupId>
-            <artifactId>aws-glue-datacatalog-spark-client</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Issue #7

Description of changes: Removes a Spark dependency from the hive client so that it can compile.
I'm unsure if that dependency is needed for other things, but `mvn test` seems to run fine without it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
