### PR TITLE
Assign catalogId before checking default database in AWSCatalogMetastoreClient

### DIFF
--- a/aws-glue-datacatalog-hive2-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-hive2-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -162,10 +162,10 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
     glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueClient, wh);
 
     snapshotActiveConf();
+    catalogId = MetastoreClientUtils.getCatalogId(conf);
     if (!doesDefaultDBExist()) {
       createDefaultDatabase();
     }
-    catalogId = MetastoreClientUtils.getCatalogId(conf);
   }
 
   /**

--- a/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -151,10 +151,10 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
     glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueClient, wh);
 
     snapshotActiveConf();
+    catalogId = MetastoreClientUtils.getCatalogId(conf);
     if (!doesDefaultDBExist()) {
       createDefaultDatabase();
     }
-    catalogId = MetastoreClientUtils.getCatalogId(conf);
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/issues/12

*Description of changes:*

Fix the order of assigning the `this.catalogId` and checking the `default` database in `AWSCatalogMetastoreClient`'s constructor: assign the `this.catalogId` first, then check the `default` database.

The constructors involved are unfortunately hard to test with mocks, so no new unit tests were added to `AWSCatalogMetastoreClientTest`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
