### PR TITLE
update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Obtain a copy of Hive from GitHub at https://github.com/apache/hive.
 
 To build the Hive client, you need to first apply this [patch](https://issues.apache.org/jira/secure/attachment/12958418/HIVE-12679.branch-2.3.patch).  Download this patch and move it to your local Hive git repository you created above.  Apply the patch and build Hive.
 
-	git checkout branch-2.3
+	git checkout tags/rel/release-2.3.4 -branch rel-2.3.4
 	patch -p0 <HIVE-12679.branch-2.3.patch
 	mvn clean install -DskipTests
 
-If you are using the default Maven settings, this will install a new version of patched Hive in ~/.m2/repositories/, i.e. ~/.m2/repository/org/apache/hive/hive/2.3.4-SNAPSHOT/.  The specific version of Hive will depend on the current version in pom.xml.  Presently, the latest version in the 2.3 branch (branch-2.3) is "2.3.4-SNAPSHOT".  You will need this version to build the client.
+Note that the `IMetaStore` API changed in version 2.3.6-SNAPSHOT that is not compatible with the client.
 
 ## Building the Hive Client
 
@@ -44,6 +44,15 @@ As Spark uses a fork of Hive based off the 1.2.1 branch, in order to build the S
 Go back to the AWS Glue Data Catalog Client repository and update the following property in pom.xml to match the version of Hive you just patched and installed locally.  Presently, the latest version in the 1.2 branch (branch-1.2) is "1.2.3-SNAPSHOT".
 
 	<spark-hive.version>1.2.3-SNAPSHOT</spark-hive.version>
+
+You've built the Hive 1.2.x branch under the `org.apache.hive` folder of your local maven repository. Next create a copy of these jars to the directory where maven expects to find the files.
+
+	mkdir -p ~/.m2/repository/org/spark-project/hive/hive-metastore
+	mkdir -p ~/.m2/repository/org/spark-project/hive/hive-exec
+
+
+	cp -R ~/.m2/repository/org/apache/hive/hive-metastore/1.2.3-SNAPSHOT ~/.m2/repository/org/spark-project/hive/hive-metastore/
+	cp -R ~/.m2/repository/org/apache/hive/hive-exec/1.2.3-SNAPSHOT ~/.m2/repository/org/spark-project/hive/hive-exec/
 
 You are now ready to build the Spark client.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Obtain a copy of Hive from GitHub at https://github.com/apache/hive.
 
 To build the Hive client, you need to first apply this [patch](https://issues.apache.org/jira/secure/attachment/12958418/HIVE-12679.branch-2.3.patch).  Download this patch and move it to your local Hive git repository you created above.  Apply the patch and build Hive.
 
-	git checkout tags/rel/release-2.3.4 -branch rel-2.3.4
+	git checkout tags/rel/release-2.3.4 -b rel-2.3.4
 	patch -p0 <HIVE-12679.branch-2.3.patch
 	mvn clean install -DskipTests
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Outdated step
  * `branch-2.3` of hive will cause issues due to API change [here](https://github.com/apache/hive/blob/branch-2.3/metastore/src/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java#L561) that will cause this error downstream
```error: AWSCatalogMetastoreClient is not abstract and does not override abstract method listPartitionValues(PartitionValuesRequest) in IMetaStoreClient```

Missing step
  * Building hive `1.2` will put files into `~/.m2/repository/org/apache/hive/` ... whereas these need to be under `~/.m2/repository/org/spark-project/hive/`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.