### PR TITLE
Remove duplicate guava dependency declaration

### DIFF
--- a/aws-glue-datacatalog-client-common/pom.xml
+++ b/aws-glue-datacatalog-client-common/pom.xml
@@ -69,11 +69,6 @@
             <artifactId>shims-loader</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
this fixes the warning from maven:
"'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique"
by only declaring the guava version once.

*Issue #, if available:*
30

*Description of changes:*
Removes the duplicate guava dependency declaration in aws-glue-datacatalog-client-common/pom.xml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
