### PR TITLE
Cache for Get All Databases

### DIFF
--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
@@ -17,102 +17,103 @@ import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE
 import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
 import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
 
-import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class AWSGlueMetastoreCacheDecorator extends AWSGlueMetastoreBaseDecorator {
 
-	private static final Logger logger = Logger.getLogger(AWSGlueMetastoreCacheDecorator.class);
+    private static final Logger logger = Logger.getLogger(AWSGlueMetastoreCacheDecorator.class);
 
-	private final HiveConf conf;
+    private final HiveConf conf;
 
-	private final boolean databaseCacheEnabled;
+    private final boolean databaseCacheEnabled;
 
-	private final boolean tableCacheEnabled;
+    private final boolean tableCacheEnabled;
 
-	@VisibleForTesting
-	protected Cache<String, Database> databaseCache;
-	@VisibleForTesting
-	protected Cache<TableIdentifier, Table> tableCache;
-	@VisibleForTesting
+    @VisibleForTesting
+    protected Cache<String, Database> databaseCache;
+    @VisibleForTesting
+    protected Cache<TableIdentifier, Table> tableCache;
+    @VisibleForTesting
 	protected Cache<String, Database> allDatabasesCache;
 
-	public AWSGlueMetastoreCacheDecorator(HiveConf conf, AWSGlueMetastore awsGlueMetastore) {
-		super(awsGlueMetastore);
+    public AWSGlueMetastoreCacheDecorator(HiveConf conf, AWSGlueMetastore awsGlueMetastore) {
+        super(awsGlueMetastore);
 
-		checkNotNull(conf, "conf can not be null");
-		this.conf = conf;
+        checkNotNull(conf, "conf can not be null");
+        this.conf = conf;
 
-		databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
-		if (databaseCacheEnabled) {
-			int dbCacheSize = conf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0);
-			int dbCacheTtlMins = conf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0);
+        databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        if(databaseCacheEnabled) {
+            int dbCacheSize = conf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0);
+            int dbCacheTtlMins = conf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0);
 
-			// validate config values for size and ttl
-			validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_SIZE, dbCacheSize);
-			validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_TTL_MINS, dbCacheTtlMins);
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_SIZE, dbCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_TTL_MINS, dbCacheTtlMins);
 
-			// initialize database cache
-			databaseCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
-					.expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
-			// initialize database cache
-			allDatabasesCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
-					.expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
-		} else {
-			databaseCache = null;
-			allDatabasesCache = null;
-		}
+            //initialize database cache
+            databaseCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+                    .expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+            
+         // initialize all database cache
+         	allDatabasesCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+         			.expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            databaseCache = null;
+            allDatabasesCache = null;
+        }
 
-		tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
-		if (tableCacheEnabled) {
-			int tableCacheSize = conf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0);
-			int tableCacheTtlMins = conf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0);
+        tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+        if(tableCacheEnabled) {
+            int tableCacheSize = conf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0);
+            int tableCacheTtlMins = conf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0);
 
-			// validate config values for size and ttl
-			validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_SIZE, tableCacheSize);
-			validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_TTL_MINS, tableCacheTtlMins);
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_SIZE, tableCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_TTL_MINS, tableCacheTtlMins);
 
-			// initialize table cache
-			tableCache = CacheBuilder.newBuilder().maximumSize(tableCacheSize)
-					.expireAfterWrite(tableCacheTtlMins, TimeUnit.MINUTES).build();
-		} else {
-			tableCache = null;
-		}
+            //initialize table cache
+            tableCache = CacheBuilder.newBuilder().maximumSize(tableCacheSize)
+                    .expireAfterWrite(tableCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            tableCache = null;
+        }
 
-		logger.info("Constructed");
-	}
+        logger.info("Constructed");
+    }
 
-	private void validateConfigValueIsGreaterThanZero(String configName, int value) {
-		checkArgument(value > 0,
-				String.format("Invalid value for Hive Config %s. " + "Provide a value greater than zero", configName));
+    private void validateConfigValueIsGreaterThanZero(String configName, int value) {
+        checkArgument(value > 0, String.format("Invalid value for Hive Config %s. " +
+                "Provide a value greater than zero", configName));
 
-	}
+    }
 
-	@Override
-	public Database getDatabase(String dbName) {
-		Database result;
-		if (databaseCacheEnabled) {
-			Database valueFromCache = databaseCache.getIfPresent(dbName);
-			if (valueFromCache != null) {
-				logger.info("Cache hit for operation [getDatabase] on key [" + dbName + "]");
-				result = valueFromCache;
-			} else {
-				logger.info("Cache miss for operation [getDatabase] on key [" + dbName + "]");
-				result = super.getDatabase(dbName);
-				databaseCache.put(dbName, result);
-			}
-		} else {
-			result = super.getDatabase(dbName);
-		}
-		return result;
-	}
-
-	@Override
+    @Override
+    public Database getDatabase(String dbName) {
+        Database result;
+        if(databaseCacheEnabled) {
+            Database valueFromCache = databaseCache.getIfPresent(dbName);
+            if(valueFromCache != null) {
+                logger.info("Cache hit for operation [getDatabase] on key [" + dbName + "]");
+                result = valueFromCache;
+            } else {
+                logger.info("Cache miss for operation [getDatabase] on key [" + dbName + "]");
+                result = super.getDatabase(dbName);
+                databaseCache.put(dbName, result);
+            }
+        } else {
+            result = super.getDatabase(dbName);
+        }
+        return result;
+    }
+    
+    @Override
 	public List<Database> getAllDatabases() {
 		List<Database> result;
 		if (databaseCacheEnabled) {
@@ -133,104 +134,106 @@ public class AWSGlueMetastoreCacheDecorator extends AWSGlueMetastoreBaseDecorato
 		return result;
 	}
 
-	
-	@Override
-	public void updateDatabase(String dbName, DatabaseInput databaseInput) {
-		super.updateDatabase(dbName, databaseInput);
-		if (databaseCacheEnabled) {
-			purgeDatabaseFromCache(dbName);
-		}
-	}
+    @Override
+    public void updateDatabase(String dbName, DatabaseInput databaseInput) {
+        super.updateDatabase(dbName, databaseInput);
+        if(databaseCacheEnabled) {
+            purgeDatabaseFromCache(dbName);
+        }
+    }
 
-	@Override
-	public void deleteDatabase(String dbName) {
-		super.deleteDatabase(dbName);
-		if (databaseCacheEnabled) {
-			purgeDatabaseFromCache(dbName);
-		}
-	}
+    @Override
+    public void deleteDatabase(String dbName) {
+        super.deleteDatabase(dbName);
+        if(databaseCacheEnabled) {
+            purgeDatabaseFromCache(dbName);
+        }
+    }
 
-	private void purgeDatabaseFromCache(String dbName) {
-		databaseCache.invalidate(dbName);
-		allDatabasesCache.invalidate(dbName);
-	}
+    private void purgeDatabaseFromCache(String dbName) {
+        databaseCache.invalidate(dbName);
+        allDatabasesCache.invalidate(dbName);
+    }
 
-	@Override
-	public Table getTable(String dbName, String tableName) {
-		Table result;
-		if (tableCacheEnabled) {
-			TableIdentifier key = new TableIdentifier(dbName, tableName);
-			Table valueFromCache = tableCache.getIfPresent(key);
-			if (valueFromCache != null) {
-				logger.info("Cache hit for operation [getTable] on key [" + key + "]");
-				result = valueFromCache;
-			} else {
-				logger.info("Cache miss for operation [getTable] on key [" + key + "]");
-				result = super.getTable(dbName, tableName);
-				tableCache.put(key, result);
-			}
-		} else {
-			result = super.getTable(dbName, tableName);
-		}
-		return result;
-	}
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        Table result;
+        if(tableCacheEnabled) {
+            TableIdentifier key = new TableIdentifier(dbName, tableName);
+            Table valueFromCache = tableCache.getIfPresent(key);
+            if(valueFromCache != null) {
+                logger.info("Cache hit for operation [getTable] on key [" + key + "]");
+                result = valueFromCache;
+            } else {
+                logger.info("Cache miss for operation [getTable] on key [" + key + "]");
+                result = super.getTable(dbName, tableName);
+                tableCache.put(key, result);
+            }
+        } else {
+            result = super.getTable(dbName, tableName);
+        }
+        return result;
+    }
 
-	@Override
-	public void updateTable(String dbName, TableInput tableInput) {
-		super.updateTable(dbName, tableInput);
-		if (tableCacheEnabled) {
-			purgeTableFromCache(dbName, tableInput.getName());
-		}
-	}
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        super.updateTable(dbName, tableInput);
+        if(tableCacheEnabled) {
+            purgeTableFromCache(dbName, tableInput.getName());
+        }
+    }
 
-	@Override
-	public void deleteTable(String dbName, String tableName) {
-		super.deleteTable(dbName, tableName);
-		if (tableCacheEnabled) {
-			purgeTableFromCache(dbName, tableName);
-		}
-	}
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        super.deleteTable(dbName, tableName);
+        if(tableCacheEnabled) {
+            purgeTableFromCache(dbName, tableName);
+        }
+    }
 
-	private void purgeTableFromCache(String dbName, String tableName) {
-		TableIdentifier key = new TableIdentifier(dbName, tableName);
-		tableCache.invalidate(key);
-	}
+    private void purgeTableFromCache(String dbName, String tableName) {
+        TableIdentifier key = new TableIdentifier(dbName, tableName);
+        tableCache.invalidate(key);
+    }
 
-	static class TableIdentifier {
-		private final String dbName;
-		private final String tableName;
 
-		public TableIdentifier(String dbName, String tableName) {
-			this.dbName = dbName;
-			this.tableName = tableName;
-		}
+    static class TableIdentifier {
+        private final String dbName;
+        private final String tableName;
 
-		public String getDbName() {
-			return dbName;
-		}
+        public TableIdentifier(String dbName, String tableName) {
+            this.dbName = dbName;
+            this.tableName = tableName;
+        }
 
-		public String getTableName() {
-			return tableName;
-		}
+        public String getDbName() {
+            return dbName;
+        }
 
-		@Override
-		public String toString() {
-			return "TableIdentifier{" + "dbName='" + dbName + '\'' + ", tableName='" + tableName + '\'' + '}';
-		}
+        public String getTableName() {
+            return tableName;
+        }
 
-		@Override
-		public boolean equals(Object o) {
-			if (this == o)
-				return true;
-			if (o == null || getClass() != o.getClass())
-				return false;
-			TableIdentifier that = (TableIdentifier) o;
-			return Objects.equals(dbName, that.dbName) && Objects.equals(tableName, that.tableName);
-		}
+        @Override
+        public String toString() {
+            return "TableIdentifier{" +
+                    "dbName='" + dbName + '\'' +
+                    ", tableName='" + tableName + '\'' +
+                    '}';
+        }
 
-		@Override
-		public int hashCode() {
-			return Objects.hash(dbName, tableName);
-		}
-	}
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TableIdentifier that = (TableIdentifier) o;
+            return Objects.equals(dbName, that.dbName) &&
+                    Objects.equals(tableName, that.tableName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, tableName);
+        }
+    }
 }

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
@@ -17,7 +17,9 @@ import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE
 import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
 import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -25,184 +27,210 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class AWSGlueMetastoreCacheDecorator extends AWSGlueMetastoreBaseDecorator {
 
-    private static final Logger logger = Logger.getLogger(AWSGlueMetastoreCacheDecorator.class);
+	private static final Logger logger = Logger.getLogger(AWSGlueMetastoreCacheDecorator.class);
 
-    private final HiveConf conf;
+	private final HiveConf conf;
 
-    private final boolean databaseCacheEnabled;
+	private final boolean databaseCacheEnabled;
 
-    private final boolean tableCacheEnabled;
+	private final boolean tableCacheEnabled;
 
-    @VisibleForTesting
-    protected Cache<String, Database> databaseCache;
-    @VisibleForTesting
-    protected Cache<TableIdentifier, Table> tableCache;
+	@VisibleForTesting
+	protected Cache<String, Database> databaseCache;
+	@VisibleForTesting
+	protected Cache<TableIdentifier, Table> tableCache;
+	@VisibleForTesting
+	protected Cache<String, Database> allDatabasesCache;
 
-    public AWSGlueMetastoreCacheDecorator(HiveConf conf, AWSGlueMetastore awsGlueMetastore) {
-        super(awsGlueMetastore);
+	public AWSGlueMetastoreCacheDecorator(HiveConf conf, AWSGlueMetastore awsGlueMetastore) {
+		super(awsGlueMetastore);
 
-        checkNotNull(conf, "conf can not be null");
-        this.conf = conf;
+		checkNotNull(conf, "conf can not be null");
+		this.conf = conf;
 
-        databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
-        if(databaseCacheEnabled) {
-            int dbCacheSize = conf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0);
-            int dbCacheTtlMins = conf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0);
+		databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+		if (databaseCacheEnabled) {
+			int dbCacheSize = conf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0);
+			int dbCacheTtlMins = conf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0);
 
-            //validate config values for size and ttl
-            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_SIZE, dbCacheSize);
-            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_TTL_MINS, dbCacheTtlMins);
+			// validate config values for size and ttl
+			validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_SIZE, dbCacheSize);
+			validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_TTL_MINS, dbCacheTtlMins);
 
-            //initialize database cache
-            databaseCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
-                    .expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
-        } else {
-            databaseCache = null;
-        }
+			// initialize database cache
+			databaseCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+					.expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+			// initialize database cache
+			allDatabasesCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+					.expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+		} else {
+			databaseCache = null;
+			allDatabasesCache = null;
+		}
 
-        tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
-        if(tableCacheEnabled) {
-            int tableCacheSize = conf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0);
-            int tableCacheTtlMins = conf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0);
+		tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+		if (tableCacheEnabled) {
+			int tableCacheSize = conf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0);
+			int tableCacheTtlMins = conf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0);
 
-            //validate config values for size and ttl
-            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_SIZE, tableCacheSize);
-            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_TTL_MINS, tableCacheTtlMins);
+			// validate config values for size and ttl
+			validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_SIZE, tableCacheSize);
+			validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_TTL_MINS, tableCacheTtlMins);
 
-            //initialize table cache
-            tableCache = CacheBuilder.newBuilder().maximumSize(tableCacheSize)
-                    .expireAfterWrite(tableCacheTtlMins, TimeUnit.MINUTES).build();
-        } else {
-            tableCache = null;
-        }
+			// initialize table cache
+			tableCache = CacheBuilder.newBuilder().maximumSize(tableCacheSize)
+					.expireAfterWrite(tableCacheTtlMins, TimeUnit.MINUTES).build();
+		} else {
+			tableCache = null;
+		}
 
-        logger.info("Constructed");
-    }
+		logger.info("Constructed");
+	}
 
-    private void validateConfigValueIsGreaterThanZero(String configName, int value) {
-        checkArgument(value > 0, String.format("Invalid value for Hive Config %s. " +
-                "Provide a value greater than zero", configName));
+	private void validateConfigValueIsGreaterThanZero(String configName, int value) {
+		checkArgument(value > 0,
+				String.format("Invalid value for Hive Config %s. " + "Provide a value greater than zero", configName));
 
-    }
+	}
 
-    @Override
-    public Database getDatabase(String dbName) {
-        Database result;
-        if(databaseCacheEnabled) {
-            Database valueFromCache = databaseCache.getIfPresent(dbName);
-            if(valueFromCache != null) {
-                logger.info("Cache hit for operation [getDatabase] on key [" + dbName + "]");
-                result = valueFromCache;
-            } else {
-                logger.info("Cache miss for operation [getDatabase] on key [" + dbName + "]");
-                result = super.getDatabase(dbName);
-                databaseCache.put(dbName, result);
-            }
-        } else {
-            result = super.getDatabase(dbName);
-        }
-        return result;
-    }
+	@Override
+	public Database getDatabase(String dbName) {
+		Database result;
+		if (databaseCacheEnabled) {
+			Database valueFromCache = databaseCache.getIfPresent(dbName);
+			if (valueFromCache != null) {
+				logger.info("Cache hit for operation [getDatabase] on key [" + dbName + "]");
+				result = valueFromCache;
+			} else {
+				logger.info("Cache miss for operation [getDatabase] on key [" + dbName + "]");
+				result = super.getDatabase(dbName);
+				databaseCache.put(dbName, result);
+			}
+		} else {
+			result = super.getDatabase(dbName);
+		}
+		return result;
+	}
 
-    @Override
-    public void updateDatabase(String dbName, DatabaseInput databaseInput) {
-        super.updateDatabase(dbName, databaseInput);
-        if(databaseCacheEnabled) {
-            purgeDatabaseFromCache(dbName);
-        }
-    }
+	@Override
+	public List<Database> getAllDatabases() {
+		List<Database> result;
+		if (databaseCacheEnabled) {
+			List<Database> valueFromCache = (List<Database>) allDatabasesCache.asMap().values();
+			if (!valueFromCache.isEmpty()) {
+				logger.info("Cache hit for operation [getAllDatabases]");
+				result = valueFromCache;
+			} else {
+				logger.info("Cache miss for operation [getAllDatabases]");
+				result = super.getAllDatabases();
+				for (Database db : result) {
+					allDatabasesCache.put(db.getName(), db);
+				}
+			}
+		} else {
+			result = super.getAllDatabases();
+		}
+		return result;
+	}
 
-    @Override
-    public void deleteDatabase(String dbName) {
-        super.deleteDatabase(dbName);
-        if(databaseCacheEnabled) {
-            purgeDatabaseFromCache(dbName);
-        }
-    }
+	
+	@Override
+	public void updateDatabase(String dbName, DatabaseInput databaseInput) {
+		super.updateDatabase(dbName, databaseInput);
+		if (databaseCacheEnabled) {
+			purgeDatabaseFromCache(dbName);
+		}
+	}
 
-    private void purgeDatabaseFromCache(String dbName) {
-        databaseCache.invalidate(dbName);
-    }
+	@Override
+	public void deleteDatabase(String dbName) {
+		super.deleteDatabase(dbName);
+		if (databaseCacheEnabled) {
+			purgeDatabaseFromCache(dbName);
+		}
+	}
 
-    @Override
-    public Table getTable(String dbName, String tableName) {
-        Table result;
-        if(tableCacheEnabled) {
-            TableIdentifier key = new TableIdentifier(dbName, tableName);
-            Table valueFromCache = tableCache.getIfPresent(key);
-            if(valueFromCache != null) {
-                logger.info("Cache hit for operation [getTable] on key [" + key + "]");
-                result = valueFromCache;
-            } else {
-                logger.info("Cache miss for operation [getTable] on key [" + key + "]");
-                result = super.getTable(dbName, tableName);
-                tableCache.put(key, result);
-            }
-        } else {
-            result = super.getTable(dbName, tableName);
-        }
-        return result;
-    }
+	private void purgeDatabaseFromCache(String dbName) {
+		databaseCache.invalidate(dbName);
+		allDatabasesCache.invalidate(dbName);
+	}
 
-    @Override
-    public void updateTable(String dbName, TableInput tableInput) {
-        super.updateTable(dbName, tableInput);
-        if(tableCacheEnabled) {
-            purgeTableFromCache(dbName, tableInput.getName());
-        }
-    }
+	@Override
+	public Table getTable(String dbName, String tableName) {
+		Table result;
+		if (tableCacheEnabled) {
+			TableIdentifier key = new TableIdentifier(dbName, tableName);
+			Table valueFromCache = tableCache.getIfPresent(key);
+			if (valueFromCache != null) {
+				logger.info("Cache hit for operation [getTable] on key [" + key + "]");
+				result = valueFromCache;
+			} else {
+				logger.info("Cache miss for operation [getTable] on key [" + key + "]");
+				result = super.getTable(dbName, tableName);
+				tableCache.put(key, result);
+			}
+		} else {
+			result = super.getTable(dbName, tableName);
+		}
+		return result;
+	}
 
-    @Override
-    public void deleteTable(String dbName, String tableName) {
-        super.deleteTable(dbName, tableName);
-        if(tableCacheEnabled) {
-            purgeTableFromCache(dbName, tableName);
-        }
-    }
+	@Override
+	public void updateTable(String dbName, TableInput tableInput) {
+		super.updateTable(dbName, tableInput);
+		if (tableCacheEnabled) {
+			purgeTableFromCache(dbName, tableInput.getName());
+		}
+	}
 
-    private void purgeTableFromCache(String dbName, String tableName) {
-        TableIdentifier key = new TableIdentifier(dbName, tableName);
-        tableCache.invalidate(key);
-    }
+	@Override
+	public void deleteTable(String dbName, String tableName) {
+		super.deleteTable(dbName, tableName);
+		if (tableCacheEnabled) {
+			purgeTableFromCache(dbName, tableName);
+		}
+	}
 
+	private void purgeTableFromCache(String dbName, String tableName) {
+		TableIdentifier key = new TableIdentifier(dbName, tableName);
+		tableCache.invalidate(key);
+	}
 
-    static class TableIdentifier {
-        private final String dbName;
-        private final String tableName;
+	static class TableIdentifier {
+		private final String dbName;
+		private final String tableName;
 
-        public TableIdentifier(String dbName, String tableName) {
-            this.dbName = dbName;
-            this.tableName = tableName;
-        }
+		public TableIdentifier(String dbName, String tableName) {
+			this.dbName = dbName;
+			this.tableName = tableName;
+		}
 
-        public String getDbName() {
-            return dbName;
-        }
+		public String getDbName() {
+			return dbName;
+		}
 
-        public String getTableName() {
-            return tableName;
-        }
+		public String getTableName() {
+			return tableName;
+		}
 
-        @Override
-        public String toString() {
-            return "TableIdentifier{" +
-                    "dbName='" + dbName + '\'' +
-                    ", tableName='" + tableName + '\'' +
-                    '}';
-        }
+		@Override
+		public String toString() {
+			return "TableIdentifier{" + "dbName='" + dbName + '\'' + ", tableName='" + tableName + '\'' + '}';
+		}
 
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            TableIdentifier that = (TableIdentifier) o;
-            return Objects.equals(dbName, that.dbName) &&
-                    Objects.equals(tableName, that.tableName);
-        }
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+			TableIdentifier that = (TableIdentifier) o;
+			return Objects.equals(dbName, that.dbName) && Objects.equals(tableName, that.tableName);
+		}
 
-        @Override
-        public int hashCode() {
-            return Objects.hash(dbName, tableName);
-        }
-    }
+		@Override
+		public int hashCode() {
+			return Objects.hash(dbName, tableName);
+		}
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change would enable caching of Glue objects for ALL DATABASES. A single database cache was already implemented in the code and this functionality overrides the getAllDatabases method for caching. No new client configuration is required to enable all database cache, it would be enabled if the client enables Database cache.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
