### PR TITLE
Corrected the hive property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ If you have both versions of Hive patched and installed locally, you can build b
 
 ## Configuring Hive to Use the Hive Client
 
-You need to ensure that the AWS Glue Data Catalog Client jar is in Hive's CLASSPATH and also set the "hive.metastore.client.factory.class" HiveConf variable for Hive to pick up and instantiate the AWS Glue Data Catalog Client.  For instance, on Amazon EMR, the client jar is located in /usr/lib/hive/lib/ and the HiveConf is set in /usr/lib/hive/conf/hive-site.xml.
+You need to ensure that the AWS Glue Data Catalog Client jar is in Hive's CLASSPATH and also set the "hive.imetastoreclient.factory.class" HiveConf variable for Hive to pick up and instantiate the AWS Glue Data Catalog Client.  For instance, on Amazon EMR, the client jar is located in /usr/lib/hive/lib/ and the HiveConf is set in /usr/lib/hive/conf/hive-site.xml.
 
 	<property>
- 		<name>hive.metastore.client.factory.class</name>
+ 		<name>hive.imetastoreclient.factory.class</name>
  		<value>com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory</value>
 	</property>
 


### PR DESCRIPTION
Corrected the property name for configuring Hive to Use the Hive Client.

*Issue #, if available:*

*Description of changes:* Corrected the property name for configuring Hive to Use the Hive Client.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
