### PR TITLE
Fix an issue for expired cached entries throwing NPE (issue #53)

### DIFF
--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/FakeTicker.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/FakeTicker.java
@@ -1,0 +1,24 @@
+package com.amazonaws.glue.catalog.util;
+
+import com.google.common.base.Ticker;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class FakeTicker extends Ticker {
+
+    private final AtomicLong nanos = new AtomicLong();
+
+    /**
+     * Advances the ticker value by {@code time} in {@code timeUnit}.
+     */
+    public FakeTicker advance(long time, TimeUnit timeUnit) {
+        nanos.addAndGet(timeUnit.toNanos(time));
+        return this;
+    }
+
+    @Override
+    public long read() {
+        return nanos.get();
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/FakeTicker.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/FakeTicker.java
@@ -22,3 +22,4 @@ public class FakeTicker extends Ticker {
         return nanos.get();
     }
 }
+


### PR DESCRIPTION
*Issue #, if available:* #53 

*Description of changes:*

Currently, `AWSGlueMetastoreCacheDecorator` uses guava cache's `size` method for checking whether it should pull from cache or not before retrieving a cached entry using `getIfPresent`.

This causes two problems:
- Invocation of `size` method does not clear out expired entries, meaning that the result could also include expired entries. (Note that Guava cache doesn't clean up cache aggressively by default). This means that even when databases cache has its entry for DATABASES_CACHE_KEY expired already, it can still return positive # of size, which would make AWSGlueMetastoreCacheDecorator to read from the cache. Then, getIfPresent for DATABASES_CACHE_KEY will return null as the entry has expired. Finally, AWSGlueMetastoreCacheDecorator would attempt to iterate on null, triggering NullPointerException.
- there can be a race condition where the cached entry expire between check (`size`) and read (`getIfPresent`). When that happens, we could still run into `NullPointerException` even if `AWSGlueMetastoreCacheDecorator` clear out expired entries before calling `size`.

This pr fixes above issues by combining `check` & `read` and removing the use of `size` for deciding whether to read from cache or not.

This pr was tested via a new unit test where a manual ticker is introduced & used in order to simulate cache entry expiration and make sure it re-fetches the list of databases from the metastore without throwing NPE.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
