### PR TITLE
Update project to allow compilation with jdk11

### DIFF
--- a/aws-glue-datacatalog-client-common/pom.xml
+++ b/aws-glue-datacatalog-client-common/pom.xml
@@ -16,6 +16,12 @@
             <artifactId>hive-metastore</artifactId>
             <version>${hive2.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>
@@ -24,21 +30,22 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-glue</artifactId>
             <version>${aws.sdk.version}</version>
-            <scope>compile</scope>
+            <scope>${aws.deps.scope}</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>${aws.sdk.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+            <scope>${aws.deps.scope}</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -59,12 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws.glue</groupId>
             <artifactId>shims-loader</artifactId>
             <version>${project.version}</version>
@@ -73,6 +74,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+            <scope>${guava.deps.scope}</scope>
         </dependency>
     </dependencies>
 

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
@@ -116,7 +116,7 @@ public class GlueMetastoreClientDelegateTest {
 
   private GlueMetastoreClientDelegate metastoreClientDelegate;
   private GlueMetastoreClientDelegate metastoreClientDelegateCatalogId;
-  
+
   private HiveConf conf;
   HiveConf hiveConfCatalogId; // conf with CatalogId
   private AWSGlue glueClient;
@@ -135,7 +135,7 @@ public class GlueMetastoreClientDelegateTest {
     glueClient = mock(AWSGlue.class);
     wh = mock(Warehouse.class);
     metastoreClientDelegate = new GlueMetastoreClientDelegate(conf, new DefaultAWSGlueMetastore(conf, glueClient), wh);
-    
+
     // Create a client delegate with CatalogId
     hiveConfCatalogId = new HiveConf();
     hiveConfCatalogId.set(GlueMetastoreClientDelegate.CATALOG_ID_CONF, CATALOG_ID);
@@ -143,7 +143,7 @@ public class GlueMetastoreClientDelegateTest {
 
     testDb = getTestDatabase();
     testTbl= getTestTable(testDb.getName());
-    setupMockWarehouseForPath(new Path(testTbl.getStorageDescriptor().getLocation().toString()), false, true);
+    setupMockWarehouseForPath(new Path(testTbl.getStorageDescriptor().getLocation()), false, true);
   }
 
   private void setupMockWarehouseForPath(Path path, boolean isDir, boolean mkDir) throws Exception {
@@ -192,7 +192,7 @@ public class GlueMetastoreClientDelegateTest {
     verify(wh, times(1)).isDir(dbPath);
     verify(wh, never()).mkdirs(dbPath, true);
   }
-  
+
   @Test
   public void testCreateDatabaseWithoutExistingDir() throws Exception {
     Path dbPath = new Path(testDb.getLocationUri());
@@ -212,7 +212,7 @@ public class GlueMetastoreClientDelegateTest {
     List<String> dbs = metastoreClientDelegate.getDatabases("*");
     assertEquals(testDb.getName(), Iterables.getOnlyElement(dbs));
   }
-  
+
   @Test
   public void testGetDatabasesWithCatalogId() throws Exception {
     when(glueClient.getDatabases(any(GetDatabasesRequest.class))).thenReturn(
@@ -224,7 +224,7 @@ public class GlueMetastoreClientDelegateTest {
     assertEquals(CATALOG_ID, captor.getValue().getCatalogId());
     assertEquals(testDb.getName(), Iterables.getOnlyElement(dbs));
   }
-  
+
 
   @Test
   public void testGetDatabasesNullPattern() throws Exception {
@@ -254,7 +254,7 @@ public class GlueMetastoreClientDelegateTest {
     assertEquals(CATALOG_ID, request.getCatalogId());
     assertEquals("db", request.getName());
   }
-  
+
   @Test
   public void testGetAllDatabases() throws Exception {
     when(glueClient.getDatabases(any(GetDatabasesRequest.class))).thenReturn(
@@ -280,7 +280,7 @@ public class GlueMetastoreClientDelegateTest {
     metastoreClientDelegate.alterDatabase("db", CatalogToHiveConverter.convertDatabase(testDb));
     verify(glueClient, times(1)).updateDatabase(any(UpdateDatabaseRequest.class));
   }
-  
+
   @Test
   public void testAlterDatabaseWithCatalogId() throws Exception {
     metastoreClientDelegateCatalogId.alterDatabase("db", CatalogToHiveConverter.convertDatabase(testDb));
@@ -358,7 +358,7 @@ public class GlueMetastoreClientDelegateTest {
     verify(glueClient).getTables(new GetTablesRequest().withDatabaseName(testDb.getName()).withExpression("*"));
     assertThat(result, is(tableNames));
   }
-  
+
   @Test
   public void testGetTableWithCatalogId() throws Exception {
     Table tbl2 = getTestTable();
@@ -464,7 +464,7 @@ public class GlueMetastoreClientDelegateTest {
     verify(wh, never()).mkdirs(tblPath, true);
     assertEquals(CATALOG_ID, captor.getValue().getCatalogId());
   }
-  
+
   @Test
   public void testCreateTableWithoutExistingDir() throws Exception {
     Path tblPath = new Path(testTbl.getStorageDescriptor().getLocation());
@@ -671,7 +671,7 @@ public class GlueMetastoreClientDelegateTest {
     verify(glueClient, times(1)).getPartition(request);
     assertThat(result.getValues(), is(values));
   }
-  
+
   @Test
   public void testGetPartitionByValuesWithCatalogId() throws Exception {
     List<String> values = Lists.newArrayList("foo", "bar");
@@ -751,13 +751,13 @@ public class GlueMetastoreClientDelegateTest {
 
     List<org.apache.hadoop.hive.metastore.api.Partition> result
       = metastoreClientDelegateCatalogId.getPartitionsByNames(testDb.getName(), testTbl.getName(), ImmutableList.of(partitionName));
-    
+
     ArgumentCaptor<BatchGetPartitionRequest> captor = ArgumentCaptor.forClass(BatchGetPartitionRequest.class);
     verify(glueClient, times(1)).batchGetPartition(captor.capture());
     assertNotNull(result);
     assertEquals(CATALOG_ID, captor.getValue().getCatalogId());
   }
-  
+
   @Test
   public void testGetPartitionsByNamePropagateException() throws Exception {
     String exceptionMessage = "Partition not found";
@@ -838,7 +838,7 @@ public class GlueMetastoreClientDelegateTest {
       .thenAnswer(new Answer<GetPartitionsResult>() {
         @Override
         public GetPartitionsResult answer(InvocationOnMock invocation) {
-          GetPartitionsRequest request = invocation.getArgumentAt(0, GetPartitionsRequest.class);
+          GetPartitionsRequest request = invocation.getArgument(0);
           GetPartitionsResult result;
           if (request.getSegment() == null) {
             fail("Should pass in segment");
@@ -884,7 +884,7 @@ public class GlueMetastoreClientDelegateTest {
             .thenAnswer(new Answer<GetPartitionsResult>() {
               @Override
               public GetPartitionsResult answer(InvocationOnMock invocation) {
-                GetPartitionsRequest request = invocation.getArgumentAt(0, GetPartitionsRequest.class);
+                GetPartitionsRequest request = invocation.getArgument(0);
                 GetPartitionsResult result;
                 switch (request.getSegment().getSegmentNumber()) {
                   case 0:
@@ -928,7 +928,7 @@ public class GlueMetastoreClientDelegateTest {
     metastoreClientDelegate.dropPartition(testDb.getName(), testTbl.getName(), values, false, false, false);
     verify(glueClient, times(1)).deletePartition(request);
   }
-  
+
   @Test
   public void testDropPartitionUsingValuesWithCatalogId() throws Exception {
     List<String> values = Lists.newArrayList("foo", "bar");
@@ -1104,7 +1104,7 @@ public class GlueMetastoreClientDelegateTest {
     assertThat(partitionsCreated, containsInAnyOrder(partitions.toArray()));
     assertDaemonThreadPools();
   }
-  
+
   @Test
   public void testAddPartitionsTwoPagesWithCatalogId() throws Exception {
     mockBatchCreatePartitionsSucceed();
@@ -1548,9 +1548,9 @@ public class GlueMetastoreClientDelegateTest {
       }
     }
   }
-  
+
   //==================== Functions =====================
-  
+
   @Test
   public void getFunction() throws Exception {
     UserDefinedFunction udf = createUserDefinedFunction();

--- a/aws-glue-datacatalog-hive2-client/pom.xml
+++ b/aws-glue-datacatalog-hive2-client/pom.xml
@@ -16,6 +16,12 @@
             <artifactId>hive-metastore</artifactId>
             <version>${hive2.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>
@@ -24,20 +30,27 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws.glue</groupId>
             <artifactId>aws-glue-datacatalog-client-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>provided</scope>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-glue</artifactId>
+            <version>${aws.sdk.version}</version>
+            <scope>${aws.deps.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+            <scope>${httpclient.deps.scope}</scope>
         </dependency>
 
         <dependency> <!-- reuse src/test/java dependencies -->

--- a/aws-glue-datacatalog-spark-client/pom.xml
+++ b/aws-glue-datacatalog-spark-client/pom.xml
@@ -17,6 +17,12 @@
             <artifactId>hive-metastore</artifactId>
             <version>${spark-hive.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.spark-project.hive</groupId>
@@ -25,20 +31,27 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws.glue</groupId>
             <artifactId>aws-glue-datacatalog-client-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>provided</scope>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-glue</artifactId>
+            <version>${aws.sdk.version}</version>
+            <scope>${aws.deps.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+            <scope>${guava.deps.scope}</scope>
         </dependency>
 
         <dependency> <!-- reuse src/test/java dependencies -->
@@ -89,7 +102,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>

--- a/aws-glue-datacatalog-spark-client/src/test/java/com/amazonaws/glue/catalog/metastore/SparkCatalogMetastoreClientTest.java
+++ b/aws-glue-datacatalog-spark-client/src/test/java/com/amazonaws/glue/catalog/metastore/SparkCatalogMetastoreClientTest.java
@@ -24,6 +24,7 @@ public class SparkCatalogMetastoreClientTest {
 
   private AWSGlue glueClient;
   private AWSCatalogMetastoreClient metastoreClient;
+  private AWSGlueMetastoreFactory metastoreFactory;
   private Warehouse wh;
   private HiveConf conf;
   private GlueClientFactory clientFactory;
@@ -44,8 +45,11 @@ public class SparkCatalogMetastoreClientTest {
     glueClient = mock(AWSGlue.class);
     clientFactory = mock(GlueClientFactory.class);
     when(clientFactory.newClient()).thenReturn(glueClient);
+    metastoreFactory = mock(AWSGlueMetastoreFactory.class);
+    AWSGlueMetastore defaultMetastore = new DefaultAWSGlueMetastore(conf, glueClient);
+    when(metastoreFactory.newMetastore(conf)).thenReturn(defaultMetastore);
     metastoreClient = new AWSCatalogMetastoreClient.Builder().withClientFactory(clientFactory)
-      .withWarehouse(wh).createDefaults(false).withHiveConf(conf).build();
+        .withMetastoreFactory(metastoreFactory).withWarehouse(wh).createDefaults(false).withHiveConf(conf).build();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -20,17 +20,19 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>14.0.1</guava.version>
     <hive2.version>2.3.3</hive2.version>
-    <spark-hive.version>1.2.1</spark-hive.version>
+    <spark-hive.version>1.2.1.spark2</spark-hive.version>
     <aws.sdk.version>1.11.267</aws.sdk.version>
     <junit.version>4.11</junit.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.23.4</mockito.version>
     <surefire.version>2.15</surefire.version>
     <powermock.version>1.6.4</powermock.version>
     <hadoop.version>2.8.3</hadoop.version>
     <maven.eclipse.plugin.version>2.9</maven.eclipse.plugin.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.5.3</httpclient.version>
-    <guava.version>28.2-jre</guava.version>
+    <aws.deps.scope>compile</aws.deps.scope>
+    <guava.deps.scope>compile</guava.deps.scope>
+    <httpclient.deps.scope>compile</httpclient.deps.scope>
     <checkstyle.config.location>${basedir}/dev-support/check_style.xml</checkstyle.config.location>
   </properties>
 
@@ -40,17 +42,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.3.1</version>
+          <version>3.8.1</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.5</version>
+          <version>3.0.0-M5</version>
           <configuration>
             <includes>
               <include>**/*Test.java</include>
@@ -130,5 +132,41 @@
       </plugin>
     </plugins>
   </reporting>
+
+<profiles>
+  <profile>
+    <id>aws-provided</id>
+    <properties>
+      <aws.deps.scope>provided</aws.deps.scope>
+    </properties>
+  </profile>
+  <profile>
+    <id>guava-provided</id>
+    <properties>
+      <guava.deps.scope>provided</guava.deps.scope>
+      <httpclient.deps.scope>provided</httpclient.deps.scope>
+    </properties>
+  </profile>
+  <profile>
+    <id>jdk11</id>
+    <activation>
+      <activeByDefault>false</activeByDefault>
+      <jdk>11</jdk>
+    </activation>
+    <build>
+      <pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </pluginManagement>
+    </build>
+  </profile>
+</profiles>
 
 </project>

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -23,15 +23,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
             <version>${hive2.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
*Description of changes:*

 * Upgrade maven plugin versions
 * Upgrade Mockito dependency to 2.x and adjust affected tests
 * Filter out transitive hbase-client dependency that requires legacy jdk/tools.jar
 * Upgrade hadoop dependency to hadoop-client (necessary for hive metastore when hbase-client is excluded)
 * Create 'provided' profiles for Guava and AWS SDK to simplify downstream packaging

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
