### PR TITLE
Add support for client side caching of GetTable and GetDatabase response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+*.iml
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+/hive/
+/aws-glue-datacatalog-spark-client/target/
+/aws-glue-datacatalog-hive3-client/target/
+/aws-glue-datacatalog-client-common/target/
+/shims/common/target/
+/shims/hive3-shims/target/
+/shims/loader/target/
+/shims/spark-hive-shims/target/
+/.idea/
+/shims/target/
+/target/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AWS Glue provides out-of-box integration with Amazon EMR that enables customers 
 
 This is an open-source implementation of the Apache Hive Metastore client on Amazon EMR clusters that uses the AWS Glue Data Catalog as an external Hive Metastore. It serves as a reference implementation for building a Hive Metastore-compatible client that connects to the AWS Glue Data Catalog. It may be ported to other Hive Metastore-compatible platforms such as other Hadoop and Apache Spark distributions.
 
-This package is compatible with Spark 3 and Hive 3
+This package is compatible with Spark 3 and Hive 3.
 
 **Note**: in order for this client implementation to be used with Apache Hive, a patch included in this [JIRA](https://issues.apache.org/jira/browse/HIVE-12679) must be applied to it. All versions of Apache Hive running on Amazon EMR that support the AWS Glue Data Catalog as the metastore already include this patch.
 
@@ -15,7 +15,7 @@ Obtain a copy of Hive from GitHub at https://github.com/apache/hive.
 
 	git clone https://github.com/apache/hive.git
 
-To build the Hive client, you need to first apply this [patch](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/Updated_connector/branch_3.1.patch).  Download this patch and move it to your local Hive git repository you created above.  Apply the patch and build Hive.
+To build the Hive client, you need to first apply this [patch](https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/branch-3.4.0/branch_3.1.patch).  Download this patch and move it to your local Hive git repository you created above. This patch is included in the repository. Apply the patch and build Hive.
 
 	git checkout branch-3.1
 	git apply -3 ~/branch_3.1.patch
@@ -29,7 +29,7 @@ Once you have successfully patched and installed Hive locally, move into the AWS
 
 You are now ready to build the Hive client.
 
-    cd aws-glue-datacatalog-hive2-client
+    cd aws-glue-datacatalog-hive3-client
     mvn clean package -DskipTests
 
 
@@ -66,6 +66,47 @@ You need to ensure that the AWS Glue Data Catalog Client jar is in Hive's CLASSP
 ## Configuring Spark to Use the Spark Client
 
 Similarly, for Spark, you need to install the client jar in Spark's CLASSPATH and create or update Spark's own hive-site.xml to add the above property.  On Amazon EMR, this is set in /usr/lib/spark/conf/hive-site.xml.  You can also find the location of the Spark client jar in /usr/lib/spark/conf/spark-defaults.conf.
+
+## Enabling client side caching for catalog
+
+Currently, we provide support for caching:
+
+a) Table metadata - Response from Glue's GetTable operation (https://docs.aws.amazon.com/glue/latest/webapi/API_GetTable.html#API_GetTable_ResponseSyntax)
+b) Database metadata - Response from Glue's GetDatabase operation (https://docs.aws.amazon.com/glue/latest/webapi/API_GetDatabase.html#API_GetDatabase_ResponseSyntax)
+
+Both these entities have dedicated caches for themselves and can be enabled/tuned individually.
+
+To enable/tune Table cache, use the following properties in your hive/spark configuration file:
+
+	<property>
+ 		<name>aws.glue.cache.table.enable</name>
+ 		<value>true</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.table.size</name>
+ 		<value>1000</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.table.ttl-mins</name>
+ 		<value>30</value>
+	</property>
+
+To enable/tune Database cache:
+
+	<property>
+ 		<name>aws.glue.cache.db.enable</name>
+ 		<value>true</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.db.size</name>
+ 		<value>1000</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.db.ttl-mins</name>
+ 		<value>30</value>
+	</property>
+
+NOTE: The caching logic is disabled by default.
 
 ## License
 

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/GlueInputConverter.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/GlueInputConverter.java
@@ -71,7 +71,7 @@ public final class GlueInputConverter {
     return partitionInput;
   }
 
-  public static Collection<PartitionInput> convertToPartitionInputs(Collection<com.amazonaws.services.glue.model.Partition> parts) {
+  public static List<PartitionInput> convertToPartitionInputs(Collection<com.amazonaws.services.glue.model.Partition> parts) {
     List<PartitionInput> inputList = new ArrayList<>();
 
     for (com.amazonaws.services.glue.model.Partition part : parts) {

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueClientFactory.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueClientFactory.java
@@ -3,22 +3,21 @@ package com.amazonaws.glue.catalog.metastore;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.glue.catalog.util.MetastoreClientUtils;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.AWSGlueClientBuilder;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.log4j.Logger;
+
+import java.io.IOException;
 
 import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_CATALOG_CREDENTIALS_PROVIDER_FACTORY_CLASS;
 import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_CATALOG_SEPARATOR;

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastore.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastore.java
@@ -1,0 +1,112 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.ColumnStatistics;
+import com.amazonaws.services.glue.model.ColumnStatisticsError;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.thrift.TException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is the accessor interface for using AWS Glue as a metastore.
+ * The generic AWSGlue interface{@link com.amazonaws.services.glue.AWSGlue}
+ * has a number of methods that are irrelevant for clients using Glue only
+ * as a metastore.
+ * Think of this interface as a wrapper over AWSGlue. This additional layer
+ * of abstraction achieves the following -
+ * a) Hides the non-metastore related operations present in AWSGlue
+ * b) Hides away the batching and pagination related limitations of AWSGlue
+ */
+public interface AWSGlueMetastore {
+
+    void createDatabase(DatabaseInput databaseInput);
+
+    Database getDatabase(String dbName);
+
+    List<Database> getAllDatabases();
+
+    void updateDatabase(String databaseName, DatabaseInput databaseInput);
+
+    void deleteDatabase(String dbName);
+
+    void createTable(String dbName, TableInput tableInput);
+
+    Table getTable(String dbName, String tableName);
+
+    List<Table> getTables(String dbname, String tablePattern);
+
+    void updateTable(String dbName, TableInput tableInput);
+
+    void updateTable(String dbName, TableInput tableInput, EnvironmentContext environmentContext);
+
+    void deleteTable(String dbName, String tableName);
+
+    Partition getPartition(String dbName, String tableName, List<String> partitionValues);
+
+    List<Partition> getPartitionsByNames(String dbName, String tableName,
+                                         List<PartitionValueList> partitionsToGet);
+
+    List<Partition> getPartitions(String dbName, String tableName, String expression,
+                                  long max) throws TException;
+
+    void updatePartition(String dbName, String tableName, List<String> partitionValues,
+                         PartitionInput partitionInput);
+
+    void deletePartition(String dbName, String tableName, List<String> partitionValues);
+
+    List<PartitionError> createPartitions(String dbName, String tableName,
+                                          List<PartitionInput> partitionInputs);
+
+    void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput);
+
+    UserDefinedFunction getUserDefinedFunction(String dbName, String functionName);
+
+    List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern);
+
+    List<UserDefinedFunction> getUserDefinedFunctions(String pattern);
+
+    void deleteUserDefinedFunction(String dbName, String functionName);
+
+    void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput);
+
+    void deletePartitionColumnStatistics(String dbName, String tableName, List<String> partitionValues, String colName);
+
+    void deleteTableColumnStatistics(String dbName, String tableName, String colName);
+
+    Map<String, List<ColumnStatistics>> getPartitionColumnStatistics(
+            String dbName,
+            String tableName,
+            List<String> partitionValues,
+            List<String> columnNames
+    );
+
+    List<ColumnStatistics> getTableColumnStatistics(
+            String dbName,
+            String tableName,
+            List<String> colNames
+    );
+
+    List<ColumnStatisticsError> updatePartitionColumnStatistics(
+           String dbName,
+           String tableName,
+           List<String> partitionValues,
+           List<ColumnStatistics> columnStatistics
+   );
+
+    List<ColumnStatisticsError> updateTableColumnStatistics(
+           String dbName,
+           String tableName,
+           List<ColumnStatistics> columnStatistics
+   );
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreBaseDecorator.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreBaseDecorator.java
@@ -1,0 +1,177 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.ColumnStatistics;
+import com.amazonaws.services.glue.model.ColumnStatisticsError;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.thrift.TException;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class AWSGlueMetastoreBaseDecorator implements AWSGlueMetastore {
+
+    private final AWSGlueMetastore awsGlueMetastore;
+
+    public AWSGlueMetastoreBaseDecorator(AWSGlueMetastore awsGlueMetastore) {
+        checkNotNull(awsGlueMetastore, "awsGlueMetastore can not be null");
+        this.awsGlueMetastore = awsGlueMetastore;
+    }
+
+    @Override
+    public void createDatabase(DatabaseInput databaseInput) {
+        awsGlueMetastore.createDatabase(databaseInput);
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        return awsGlueMetastore.getDatabase(dbName);
+    }
+
+    @Override
+    public List<Database> getAllDatabases() {
+        return awsGlueMetastore.getAllDatabases();
+    }
+
+    @Override
+    public void updateDatabase(String databaseName, DatabaseInput databaseInput) {
+        awsGlueMetastore.updateDatabase(databaseName, databaseInput);
+    }
+
+    @Override
+    public void deleteDatabase(String dbName) {
+        awsGlueMetastore.deleteDatabase(dbName);
+    }
+
+    @Override
+    public void createTable(String dbName, TableInput tableInput) {
+        awsGlueMetastore.createTable(dbName, tableInput);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        return awsGlueMetastore.getTable(dbName, tableName);
+    }
+
+    @Override
+    public List<Table> getTables(String dbname, String tablePattern) {
+        return awsGlueMetastore.getTables(dbname, tablePattern);
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        awsGlueMetastore.updateTable(dbName, tableInput);
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput, EnvironmentContext environmentContext) {
+        awsGlueMetastore.updateTable(dbName, tableInput, environmentContext);
+    }
+
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        awsGlueMetastore.deleteTable(dbName, tableName);
+    }
+
+    @Override
+    public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
+        return awsGlueMetastore.getPartition(dbName, tableName, partitionValues);
+    }
+
+    @Override
+    public List<Partition> getPartitionsByNames(String dbName, String tableName, List<PartitionValueList> partitionsToGet) {
+        return awsGlueMetastore.getPartitionsByNames(dbName, tableName, partitionsToGet);
+    }
+
+    @Override
+    public List<Partition> getPartitions(String dbName, String tableName, String expression, long max) throws TException {
+        return awsGlueMetastore.getPartitions(dbName, tableName, expression, max);
+    }
+
+    @Override
+    public void updatePartition(String dbName, String tableName, List<String> partitionValues, PartitionInput partitionInput) {
+        awsGlueMetastore.updatePartition(dbName, tableName, partitionValues, partitionInput);
+    }
+
+    @Override
+    public void deletePartition(String dbName, String tableName, List<String> partitionValues) {
+        awsGlueMetastore.deletePartition(dbName, tableName, partitionValues);
+    }
+
+    @Override
+    public List<PartitionError> createPartitions(String dbName, String tableName, List<PartitionInput> partitionInputs) {
+        return awsGlueMetastore.createPartitions(dbName, tableName, partitionInputs);
+    }
+
+    @Override
+    public void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput) {
+        awsGlueMetastore.createUserDefinedFunction(dbName, functionInput);
+    }
+
+    @Override
+    public UserDefinedFunction getUserDefinedFunction(String dbName, String functionName) {
+        return awsGlueMetastore.getUserDefinedFunction(dbName, functionName);
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern) {
+        return awsGlueMetastore.getUserDefinedFunctions(dbName, pattern);
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String pattern) {
+        return awsGlueMetastore.getUserDefinedFunctions(pattern);
+    }
+
+    @Override
+    public void deleteUserDefinedFunction(String dbName, String functionName) {
+        awsGlueMetastore.deleteUserDefinedFunction(dbName, functionName);
+    }
+
+    @Override
+    public void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput) {
+        awsGlueMetastore.updateUserDefinedFunction(dbName, functionName, functionInput);
+    }
+
+    @Override
+    public void deletePartitionColumnStatistics(String dbName, String tableName, List<String> partitionValues, String colName) {
+        awsGlueMetastore.deletePartitionColumnStatistics(dbName, tableName, partitionValues, colName);
+    }
+
+    @Override
+    public void deleteTableColumnStatistics(String dbName, String tableName, String colName) {
+        awsGlueMetastore.deleteTableColumnStatistics(dbName, tableName, colName);
+    }
+
+    @Override
+    public Map<String, List<ColumnStatistics>> getPartitionColumnStatistics(String dbName, String tableName, List<String> partitionValues, List<String> columnNames) {
+        return awsGlueMetastore.getPartitionColumnStatistics(dbName, tableName, partitionValues, columnNames);
+    }
+
+    @Override
+    public List<ColumnStatistics> getTableColumnStatistics(String dbName, String tableName, List<String> colNames) {
+        return awsGlueMetastore.getTableColumnStatistics(dbName, tableName, colNames);
+    }
+
+    @Override
+    public List<ColumnStatisticsError> updatePartitionColumnStatistics(String dbName, String tableName, List<String> partitionValues, List<ColumnStatistics> columnStatistics) {
+        return awsGlueMetastore.updatePartitionColumnStatistics(dbName, tableName, partitionValues, columnStatistics);
+    }
+
+    @Override
+    public List<ColumnStatisticsError> updateTableColumnStatistics(String dbName, String tableName, List<ColumnStatistics> columnStatistics) {
+        return awsGlueMetastore.updateTableColumnStatistics(dbName, tableName, columnStatistics);
+    }
+
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
@@ -1,0 +1,164 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.Table;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.log4j.Logger;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class AWSGlueMetastoreCacheDecorator extends AWSGlueMetastoreBaseDecorator {
+
+    private static final Logger logger = Logger.getLogger(AWSGlueMetastoreCacheDecorator.class);
+
+    private final Configuration conf;
+
+    private final boolean databaseCacheEnabled;
+
+    private final boolean tableCacheEnabled;
+
+    @VisibleForTesting
+    protected Cache<String, Database> databaseCache;
+    @VisibleForTesting
+    protected Cache<TableIdentifier, Table> tableCache;
+
+    public AWSGlueMetastoreCacheDecorator(Configuration conf, AWSGlueMetastore awsGlueMetastore) {
+        super(awsGlueMetastore);
+
+        checkNotNull(conf, "conf can not be null");
+        this.conf = conf;
+
+        databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        if(databaseCacheEnabled) {
+            int dbCacheSize = conf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0);
+            int dbCacheTtlMins = conf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0);
+
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_SIZE, dbCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_TTL_MINS, dbCacheTtlMins);
+
+            //initialize database cache
+            databaseCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+                    .expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            databaseCache = null;
+        }
+
+        tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+        if(tableCacheEnabled) {
+            int tableCacheSize = conf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0);
+            int tableCacheTtlMins = conf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0);
+
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_SIZE, tableCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_TTL_MINS, tableCacheTtlMins);
+
+            //initialize table cache
+            tableCache = CacheBuilder.newBuilder().maximumSize(tableCacheSize)
+                    .expireAfterWrite(tableCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            tableCache = null;
+        }
+
+        logger.info("Constructed");
+    }
+
+    private void validateConfigValueIsGreaterThanZero(String configName, int value) {
+        checkArgument(value > 0, String.format("Invalid value for Hive Config %s. " +
+                "Provide a value greater than zero", configName));
+
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        Database result;
+        if(databaseCacheEnabled) {
+            Database valueFromCache = databaseCache.getIfPresent(dbName);
+            if(valueFromCache != null) {
+                logger.info("Cache hit for operation [getDatabase] on key [" + dbName + "]");
+                result = valueFromCache;
+            } else {
+                logger.info("Cache miss for operation [getDatabase] on key [" + dbName + "]");
+                result = super.getDatabase(dbName);
+                databaseCache.put(dbName, result);
+            }
+        } else {
+            result = super.getDatabase(dbName);
+        }
+        return result;
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        Table result;
+        if(tableCacheEnabled) {
+            TableIdentifier key = new TableIdentifier(dbName, tableName);
+            Table valueFromCache = tableCache.getIfPresent(key);
+            if(valueFromCache != null) {
+                logger.info("Cache hit for operation [getTable] on key [" + key + "]");
+                result = valueFromCache;
+            } else {
+                logger.info("Cache miss for operation [getTable] on key [" + key + "]");
+                result = super.getTable(dbName, tableName);
+                tableCache.put(key, result);
+            }
+        } else {
+            result = super.getTable(dbName, tableName);
+        }
+        return result;
+    }
+
+    static class TableIdentifier {
+        private final String dbName;
+        private final String tableName;
+
+        public TableIdentifier(String dbName, String tableName) {
+            this.dbName = dbName;
+            this.tableName = tableName;
+        }
+
+        public String getDbName() {
+            return dbName;
+        }
+
+        public String getTableName() {
+            return tableName;
+        }
+
+        @Override
+        public String toString() {
+            return "TableIdentifier{" +
+                    "dbName='" + dbName + '\'' +
+                    ", tableName='" + tableName + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TableIdentifier that = (TableIdentifier) o;
+            return Objects.equals(dbName, that.dbName) &&
+                    Objects.equals(tableName, that.tableName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, tableName);
+        }
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactory.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactory.java
@@ -1,0 +1,26 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.AWSGlue;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+
+public class AWSGlueMetastoreFactory {
+
+    public AWSGlueMetastore newMetastore(Configuration conf) throws MetaException {
+        AWSGlue glueClient = new AWSGlueClientFactory(conf).newClient();
+        AWSGlueMetastore defaultMetastore = new DefaultAWSGlueMetastore(conf, glueClient);
+        if(isCacheEnabled(conf)) {
+            return new AWSGlueMetastoreCacheDecorator(conf, defaultMetastore);
+        }
+        return defaultMetastore;
+    }
+
+    private boolean isCacheEnabled(Configuration conf) {
+        boolean databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        boolean tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+        return (databaseCacheEnabled || tableCacheEnabled);
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
@@ -1,0 +1,642 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.glue.catalog.converters.PartitionNameParser;
+import com.amazonaws.glue.catalog.util.MetastoreClientUtils;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionResult;
+import com.amazonaws.services.glue.model.ColumnStatistics;
+import com.amazonaws.services.glue.model.ColumnStatisticsError;
+import com.amazonaws.services.glue.model.CreateDatabaseRequest;
+import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.CreateUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.DeleteColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.DeleteColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.DeletePartitionRequest;
+import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.DeleteUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForPartitionResult;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.GetColumnStatisticsForTableResult;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabaseResult;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetDatabasesResult;
+import com.amazonaws.services.glue.model.GetPartitionRequest;
+import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.amazonaws.services.glue.model.GetPartitionsResult;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTableResult;
+import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.GetTablesResult;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionsRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionsResult;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Segment;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForPartitionRequest;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForPartitionResult;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForTableRequest;
+import com.amazonaws.services.glue.model.UpdateColumnStatisticsForTableResult;
+import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
+import com.amazonaws.services.glue.model.UpdatePartitionRequest;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+import com.amazonaws.services.glue.model.UpdateUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.thrift.TException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
+
+    public static final int BATCH_GET_PARTITIONS_MAX_REQUEST_SIZE = 1000;
+    /**
+     * Based on the maxResults parameter at https://docs.aws.amazon.com/glue/latest/webapi/API_GetPartitions.html
+     */
+    public static final int GET_PARTITIONS_MAX_SIZE = 1000;
+    /**
+     * Maximum number of Glue Segments. A segment defines a non-overlapping region of a table's partitions,
+     * allowing multiple requests to be executed in parallel.
+     */
+    public static final int DEFAULT_NUM_PARTITION_SEGMENTS = 5;
+    /**
+     * Currently the upper limit allowed by Glue is 10.
+     * https://docs.aws.amazon.com/glue/latest/webapi/API_Segment.html
+     */
+    public static final int MAX_NUM_PARTITION_SEGMENTS = 10;
+    public static final String NUM_PARTITION_SEGMENTS_CONF = "aws.glue.partition.num.segments";
+    public static final String CUSTOM_EXECUTOR_FACTORY_CONF = "hive.metastore.executorservice.factory.class";
+
+    /**
+     * Based on the ColumnNames parameter at https://docs.aws.amazon.com/glue/latest/webapi/API_GetColumnStatisticsForPartition.html
+     */
+    public static final int GET_COLUMNS_STAT_MAX_SIZE = 100;
+    public static final int UPDATE_COLUMNS_STAT_MAX_SIZE = 25;
+
+    /**
+     * To be used with UpdateTable
+     */
+    public static final String SKIP_AWS_GLUE_ARCHIVE = "skipAWSGlueArchive";
+
+    private static final int NUM_EXECUTOR_THREADS = 5;
+    static final String GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT = "glue-metastore-delegate-%d";
+    private static final ExecutorService GLUE_METASTORE_DELEGATE_THREAD_POOL = Executors.newFixedThreadPool(
+            NUM_EXECUTOR_THREADS,
+            new ThreadFactoryBuilder()
+                    .setNameFormat(GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT)
+                    .setDaemon(true).build()
+    );
+
+    private final Configuration conf;
+    private final AWSGlue glueClient;
+    private final String catalogId;
+    private final ExecutorService executorService;
+    private final int numPartitionSegments;
+
+    protected ExecutorService getExecutorService(Configuration conf) {
+        Class<? extends ExecutorServiceFactory> executorFactoryClass = conf
+                .getClass(CUSTOM_EXECUTOR_FACTORY_CONF,
+                        DefaultExecutorServiceFactory.class).asSubclass(
+                        ExecutorServiceFactory.class);
+        ExecutorServiceFactory factory = ReflectionUtils.newInstance(
+                executorFactoryClass, conf);
+        return factory.getExecutorService(conf);
+    }
+
+    public DefaultAWSGlueMetastore(Configuration conf, AWSGlue glueClient) {
+        checkNotNull(conf, "Hive Config cannot be null");
+        checkNotNull(glueClient, "glueClient cannot be null");
+        this.numPartitionSegments = conf.getInt(NUM_PARTITION_SEGMENTS_CONF, DEFAULT_NUM_PARTITION_SEGMENTS);
+        checkArgument(numPartitionSegments <= MAX_NUM_PARTITION_SEGMENTS,
+                String.format("Hive Config [%s] can't exceed %d", NUM_PARTITION_SEGMENTS_CONF, MAX_NUM_PARTITION_SEGMENTS));
+        this.conf = conf;
+        this.glueClient = glueClient;
+        this.catalogId = MetastoreClientUtils.getCatalogId(conf);
+        this.executorService = getExecutorService(conf);
+    }
+
+    // ======================= Database =======================
+
+    @Override
+    public void createDatabase(DatabaseInput databaseInput) {
+        CreateDatabaseRequest createDatabaseRequest = new CreateDatabaseRequest().withDatabaseInput(databaseInput)
+                .withCatalogId(catalogId);
+        glueClient.createDatabase(createDatabaseRequest);
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        GetDatabaseRequest getDatabaseRequest = new GetDatabaseRequest().withCatalogId(catalogId).withName(dbName);
+        GetDatabaseResult result = glueClient.getDatabase(getDatabaseRequest);
+        return result.getDatabase();
+    }
+
+    @Override
+    public List<Database> getAllDatabases() {
+        List<Database> ret = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetDatabasesRequest getDatabasesRequest = new GetDatabasesRequest().withNextToken(nextToken).withCatalogId(
+                    catalogId);
+            GetDatabasesResult result = glueClient.getDatabases(getDatabasesRequest);
+            nextToken = result.getNextToken();
+            ret.addAll(result.getDatabaseList());
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void updateDatabase(String databaseName, DatabaseInput databaseInput) {
+        UpdateDatabaseRequest updateDatabaseRequest = new UpdateDatabaseRequest().withName(databaseName)
+                .withDatabaseInput(databaseInput).withCatalogId(catalogId);
+        glueClient.updateDatabase(updateDatabaseRequest);
+    }
+
+    @Override
+    public void deleteDatabase(String dbName) {
+        DeleteDatabaseRequest deleteDatabaseRequest = new DeleteDatabaseRequest().withName(dbName).withCatalogId(
+                catalogId);
+        glueClient.deleteDatabase(deleteDatabaseRequest);
+    }
+
+    // ======================== Table ========================
+
+    @Override
+    public void createTable(String dbName, TableInput tableInput) {
+        CreateTableRequest createTableRequest = new CreateTableRequest().withTableInput(tableInput)
+                .withDatabaseName(dbName).withCatalogId(catalogId);
+        glueClient.createTable(createTableRequest);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(dbName).withName(tableName)
+                .withCatalogId(catalogId);
+        GetTableResult result = glueClient.getTable(getTableRequest);
+        return result.getTable();
+    }
+
+    @Override
+    public List<Table> getTables(String dbname, String tablePattern) {
+        List<Table> ret = new ArrayList<>();
+        String nextToken = null;
+        do {
+            GetTablesRequest getTablesRequest = new GetTablesRequest().withDatabaseName(dbname)
+                    .withExpression(tablePattern).withNextToken(nextToken).withCatalogId(catalogId);
+            GetTablesResult result = glueClient.getTables(getTablesRequest);
+            ret.addAll(result.getTableList());
+            nextToken = result.getNextToken();
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        UpdateTableRequest updateTableRequest = new UpdateTableRequest().withDatabaseName(dbName)
+                .withTableInput(tableInput).withCatalogId(catalogId);
+        glueClient.updateTable(updateTableRequest);
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput, EnvironmentContext environmentContext) {
+        UpdateTableRequest updateTableRequest = new UpdateTableRequest().withDatabaseName(dbName)
+                .withTableInput(tableInput).withCatalogId(catalogId).withSkipArchive(skipArchive(environmentContext));
+        glueClient.updateTable(updateTableRequest);
+    }
+
+    private boolean skipArchive(EnvironmentContext environmentContext) {
+        return environmentContext != null &&
+                environmentContext.isSetProperties() &&
+                StatsSetupConst.TRUE.equals(environmentContext.getProperties().get(SKIP_AWS_GLUE_ARCHIVE));
+    }
+
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        DeleteTableRequest deleteTableRequest = new DeleteTableRequest().withDatabaseName(dbName).withName(tableName)
+                .withCatalogId(catalogId);
+        glueClient.deleteTable(deleteTableRequest);
+    }
+
+    // =========================== Partition ===========================
+
+    @Override
+    public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
+        GetPartitionRequest request = new GetPartitionRequest()
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withPartitionValues(partitionValues)
+                .withCatalogId(catalogId);
+        return glueClient.getPartition(request).getPartition();
+    }
+
+    @Override
+    public List<Partition> getPartitionsByNames(String dbName, String tableName,
+                                                List<PartitionValueList> partitionsToGet) {
+
+        List<List<PartitionValueList>> batchedPartitionsToGet = Lists.partition(partitionsToGet,
+                BATCH_GET_PARTITIONS_MAX_REQUEST_SIZE);
+        List<Future<BatchGetPartitionResult>> batchGetPartitionFutures = Lists.newArrayList();
+
+        for (List<PartitionValueList> batch : batchedPartitionsToGet) {
+            final BatchGetPartitionRequest request = new BatchGetPartitionRequest()
+                    .withDatabaseName(dbName)
+                    .withTableName(tableName)
+                    .withPartitionsToGet(batch)
+                    .withCatalogId(catalogId);
+            batchGetPartitionFutures.add(this.executorService.submit(new Callable<BatchGetPartitionResult>() {
+                @Override
+                public BatchGetPartitionResult call() throws Exception {
+                    return glueClient.batchGetPartition(request);
+                }
+            }));
+        }
+
+        List<Partition> result = Lists.newArrayList();
+        try {
+            for (Future<BatchGetPartitionResult> future : batchGetPartitionFutures) {
+                result.addAll(future.get().getPartitions());
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return result;
+    }
+
+    @Override
+    public List<Partition> getPartitions(String dbName, String tableName, String expression,
+                                         long max) throws TException {
+        if (max == 0) {
+            return Collections.emptyList();
+        }
+        if (max < 0 || max > GET_PARTITIONS_MAX_SIZE) {
+            return getPartitionsParallel(dbName, tableName, expression, max);
+        } else {
+            // We don't need to get too many partitions, so just do it serially.
+            return getCatalogPartitions(dbName, tableName, expression, max, null);
+        }
+    }
+
+    private List<Partition> getPartitionsParallel(
+            final String databaseName,
+            final String tableName,
+            final String expression,
+            final long max) throws TException {
+        // Prepare the segments
+        List<Segment> segments = Lists.newArrayList();
+        for (int i = 0; i < numPartitionSegments; i++) {
+            segments.add(new Segment()
+                    .withSegmentNumber(i)
+                    .withTotalSegments(numPartitionSegments));
+        }
+        // Submit Glue API calls in parallel using the thread pool.
+        // We could convert this into a parallelStream after upgrading to JDK 8 compiler base.
+        List<Future<List<Partition>>> futures = Lists.newArrayList();
+        for (final Segment segment : segments) {
+            futures.add(this.executorService.submit(new Callable<List<Partition>>() {
+                @Override
+                public List<Partition> call() throws Exception {
+                    return getCatalogPartitions(databaseName, tableName, expression, max, segment);
+                }
+            }));
+        }
+
+        // Get the results
+        List<Partition> partitions = Lists.newArrayList();
+        try {
+            for (Future<List<Partition>> future : futures) {
+                List<Partition> segmentPartitions = future.get();
+                if (partitions.size() + segmentPartitions.size() >= max && max > 0) {
+                    // Extract the required number of partitions from the segment and we're done.
+                    long remaining = max - partitions.size();
+                    partitions.addAll(segmentPartitions.subList(0, (int) remaining));
+                    break;
+                } else {
+                    partitions.addAll(segmentPartitions);
+                }
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return partitions;
+    }
+
+
+    private List<Partition> getCatalogPartitions(String databaseName, String tableName, String expression,
+                                                 long max, Segment segment) {
+        List<Partition> partitions = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetPartitionsRequest request = new GetPartitionsRequest()
+                    .withDatabaseName(databaseName)
+                    .withTableName(tableName)
+                    .withExpression(expression)
+                    .withNextToken(nextToken)
+                    .withCatalogId(catalogId)
+                    .withSegment(segment);
+            GetPartitionsResult res = glueClient.getPartitions(request);
+            List<Partition> list = res.getPartitions();
+            if ((partitions.size() + list.size()) >= max && max > 0) {
+                long remaining = max - partitions.size();
+                partitions.addAll(list.subList(0, (int) remaining));
+                break;
+            }
+            partitions.addAll(list);
+            nextToken = res.getNextToken();
+        } while (nextToken != null);
+        return partitions;
+    }
+
+    @Override
+    public void updatePartition(String dbName, String tableName, List<String> partitionValues,
+                                PartitionInput partitionInput) {
+        UpdatePartitionRequest updatePartitionRequest = new UpdatePartitionRequest().withDatabaseName(dbName)
+                .withTableName(tableName).withPartitionValueList(partitionValues)
+                .withPartitionInput(partitionInput).withCatalogId(catalogId);
+        glueClient.updatePartition(updatePartitionRequest);
+    }
+
+    @Override
+    public void deletePartition(String dbName, String tableName, List<String> partitionValues) {
+        DeletePartitionRequest request = new DeletePartitionRequest()
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withPartitionValues(partitionValues)
+                .withCatalogId(catalogId);
+        glueClient.deletePartition(request);
+    }
+
+    @Override
+    public List<PartitionError> createPartitions(String dbName, String tableName,
+                                                 List<PartitionInput> partitionInputs) {
+        BatchCreatePartitionRequest request =
+                new BatchCreatePartitionRequest().withDatabaseName(dbName)
+                        .withTableName(tableName).withCatalogId(catalogId)
+                        .withPartitionInputList(partitionInputs);
+        return glueClient.batchCreatePartition(request).getErrors();
+    }
+
+    // ====================== User Defined Function ======================
+
+    @Override
+    public void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput) {
+        CreateUserDefinedFunctionRequest createUserDefinedFunctionRequest = new CreateUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionInput(functionInput).withCatalogId(catalogId);
+        glueClient.createUserDefinedFunction(createUserDefinedFunctionRequest);
+    }
+
+    @Override
+    public UserDefinedFunction getUserDefinedFunction(String dbName, String functionName) {
+        GetUserDefinedFunctionRequest getUserDefinedFunctionRequest = new GetUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+        return glueClient.getUserDefinedFunction(getUserDefinedFunctionRequest).getUserDefinedFunction();
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern) {
+        List<UserDefinedFunction> ret = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetUserDefinedFunctionsRequest getUserDefinedFunctionsRequest = new GetUserDefinedFunctionsRequest()
+                    .withDatabaseName(dbName).withPattern(pattern).withNextToken(nextToken).withCatalogId(catalogId);
+            GetUserDefinedFunctionsResult result = glueClient.getUserDefinedFunctions(getUserDefinedFunctionsRequest);
+            nextToken = result.getNextToken();
+            ret.addAll(result.getUserDefinedFunctions());
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String pattern) {
+        List<UserDefinedFunction> ret = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetUserDefinedFunctionsRequest getUserDefinedFunctionsRequest = new GetUserDefinedFunctionsRequest()
+                    .withPattern(pattern).withNextToken(nextToken).withCatalogId(catalogId);
+            GetUserDefinedFunctionsResult result = glueClient.getUserDefinedFunctions(getUserDefinedFunctionsRequest);
+            nextToken = result.getNextToken();
+            ret.addAll(result.getUserDefinedFunctions());
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void deleteUserDefinedFunction(String dbName, String functionName) {
+        DeleteUserDefinedFunctionRequest deleteUserDefinedFunctionRequest = new DeleteUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+        glueClient.deleteUserDefinedFunction(deleteUserDefinedFunctionRequest);
+    }
+
+    @Override
+    public void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput) {
+        UpdateUserDefinedFunctionRequest updateUserDefinedFunctionRequest = new UpdateUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withFunctionInput(functionInput)
+                .withCatalogId(catalogId);
+        glueClient.updateUserDefinedFunction(updateUserDefinedFunctionRequest);
+    }
+
+    @Override
+    public void deletePartitionColumnStatistics(String dbName, String tableName, List<String> partitionValues, String colName) {
+        DeleteColumnStatisticsForPartitionRequest request = new DeleteColumnStatisticsForPartitionRequest()
+                .withCatalogId(catalogId)
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withPartitionValues(partitionValues)
+                .withColumnName(colName);
+        glueClient.deleteColumnStatisticsForPartition(request);
+    }
+
+    @Override
+    public void deleteTableColumnStatistics(String dbName, String tableName, String colName) {
+        DeleteColumnStatisticsForTableRequest request = new DeleteColumnStatisticsForTableRequest()
+                .withCatalogId(catalogId)
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withColumnName(colName);
+        glueClient.deleteColumnStatisticsForTable(request);
+    }
+
+    @Override
+    public Map<String, List<ColumnStatistics>> getPartitionColumnStatistics(String dbName, String tableName, List<String> partitionValues, List<String> columnNames) {
+        Map<String, List<ColumnStatistics>> partitionStatistics = new HashMap<>();
+        List<List<String>> pagedColNames = Lists.partition(columnNames, GET_COLUMNS_STAT_MAX_SIZE);
+        List<String> partValues;
+        for (String partName : partitionValues) {
+            partValues = PartitionNameParser.getPartitionValuesFromName(partName);
+            List<Future<GetColumnStatisticsForPartitionResult>> pagedResult = new ArrayList<>();
+            for (List<String> cols : pagedColNames) {
+                GetColumnStatisticsForPartitionRequest request = new GetColumnStatisticsForPartitionRequest()
+                        .withCatalogId(catalogId)
+                        .withDatabaseName(dbName)
+                        .withTableName(tableName)
+                        .withPartitionValues(partValues)
+                        .withColumnNames(cols);
+                pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<GetColumnStatisticsForPartitionResult>() {
+                    @Override
+                    public GetColumnStatisticsForPartitionResult call() throws Exception {
+                        return glueClient.getColumnStatisticsForPartition(request);
+                    }
+                }));
+            }
+
+            List<ColumnStatistics> result = new ArrayList<>();
+            for (Future<GetColumnStatisticsForPartitionResult> page : pagedResult) {
+                try {
+                    result.addAll(page.get().getColumnStatisticsList());
+                } catch (ExecutionException e) {
+                    Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+                    Throwables.propagate(e.getCause());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            partitionStatistics.put(partName, result);
+        }
+        return partitionStatistics;
+    }
+
+    @Override
+    public List<ColumnStatistics> getTableColumnStatistics(String dbName, String tableName, List<String> colNames) {
+        List<List<String>> pagedColNames = Lists.partition(colNames, GET_COLUMNS_STAT_MAX_SIZE);
+        List<Future<GetColumnStatisticsForTableResult>> pagedResult = new ArrayList<>();
+
+        for (List<String> cols : pagedColNames) {
+            GetColumnStatisticsForTableRequest request = new GetColumnStatisticsForTableRequest()
+                    .withCatalogId(catalogId)
+                    .withDatabaseName(dbName)
+                    .withTableName(tableName)
+                    .withColumnNames(cols);
+            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<GetColumnStatisticsForTableResult>() {
+                @Override
+                public GetColumnStatisticsForTableResult call() throws Exception {
+                    return glueClient.getColumnStatisticsForTable(request);
+                }
+            }));
+        }
+        List<ColumnStatistics> results = new ArrayList<>();
+
+        for (Future<GetColumnStatisticsForTableResult> page : pagedResult) {
+            try {
+                results.addAll(page.get().getColumnStatisticsList());
+            } catch (ExecutionException e) {
+                Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+                Throwables.propagate(e.getCause());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return results;
+    }
+
+    @Override
+    public List<ColumnStatisticsError> updatePartitionColumnStatistics(
+            String dbName,
+            String tableName,
+            List<String> partitionValues,
+            List<ColumnStatistics> columnStatistics) {
+
+        List<List<ColumnStatistics>> statisticsListPaged = Lists.partition(columnStatistics, UPDATE_COLUMNS_STAT_MAX_SIZE);
+        List<Future<UpdateColumnStatisticsForPartitionResult>> pagedResult = new ArrayList<>();
+        for (List<ColumnStatistics> statList : statisticsListPaged) {
+            UpdateColumnStatisticsForPartitionRequest request = new UpdateColumnStatisticsForPartitionRequest()
+                    .withCatalogId(catalogId)
+                    .withDatabaseName(dbName)
+                    .withTableName(tableName)
+                    .withPartitionValues(partitionValues)
+                    .withColumnStatisticsList(statList);
+            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<UpdateColumnStatisticsForPartitionResult>() {
+                @Override
+                public UpdateColumnStatisticsForPartitionResult call() throws Exception {
+                    return glueClient.updateColumnStatisticsForPartition(request);
+                }
+            }));
+        }
+        // Waiting for calls to finish. Will fail the call if one of the future task fails
+        List<ColumnStatisticsError> columnStatisticsErrors = new ArrayList<>();
+        try {
+            for (Future<UpdateColumnStatisticsForPartitionResult> page : pagedResult) {
+                Optional.ofNullable(page.get().getErrors()).ifPresent(error -> columnStatisticsErrors.addAll(error));
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return columnStatisticsErrors;
+    }
+
+    @Override
+    public List<ColumnStatisticsError> updateTableColumnStatistics(
+            String dbName,
+            String tableName,
+            List<ColumnStatistics> columnStatistics) {
+
+        List<List<ColumnStatistics>> statisticsListPaged = Lists.partition(columnStatistics, UPDATE_COLUMNS_STAT_MAX_SIZE);
+        List<Future<UpdateColumnStatisticsForTableResult>> pagedResult = new ArrayList<>();
+        for (List<ColumnStatistics> statList : statisticsListPaged) {
+            UpdateColumnStatisticsForTableRequest request = new UpdateColumnStatisticsForTableRequest()
+                    .withCatalogId(catalogId)
+                    .withDatabaseName(dbName)
+                    .withTableName(tableName)
+                    .withColumnStatisticsList(statList);
+            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<UpdateColumnStatisticsForTableResult>() {
+                @Override
+                public UpdateColumnStatisticsForTableResult call() throws Exception {
+                    return glueClient.updateColumnStatisticsForTable(request);
+                }
+            }));
+        }
+
+        // Waiting for calls to finish. Will fail the call if one of the future task fails
+        List<ColumnStatisticsError> columnStatisticsErrors = new ArrayList<>();
+        try {
+            for (Future<UpdateColumnStatisticsForTableResult> page : pagedResult) {
+                Optional.ofNullable(page.get().getErrors()).ifPresent(error -> columnStatisticsErrors.addAll(error));
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return columnStatisticsErrors;
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultExecutorServiceFactory.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultExecutorServiceFactory.java
@@ -1,0 +1,22 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
+    private static final int NUM_EXECUTOR_THREADS = 5;
+
+    private static final ExecutorService GLUE_METASTORE_DELEGATE_THREAD_POOL = Executors.newFixedThreadPool(
+      NUM_EXECUTOR_THREADS, new ThreadFactoryBuilder()
+        .setNameFormat(GlueMetastoreClientDelegate.GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT)
+        .setDaemon(true).build()
+    );
+
+    @Override
+    public ExecutorService getExecutorService(Configuration conf) {
+        return GLUE_METASTORE_DELEGATE_THREAD_POOL;
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/ExecutorServiceFactory.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/ExecutorServiceFactory.java
@@ -1,0 +1,12 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.concurrent.ExecutorService;
+
+/*
+ * Interface for creating an ExecutorService
+ */
+public interface ExecutorServiceFactory {
+    public ExecutorService getExecutorService(Configuration conf);
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/AWSGlueConfig.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/AWSGlueConfig.java
@@ -26,4 +26,13 @@ public final class AWSGlueConfig {
     public static final String AWS_GLUE_CATALOG_SEPARATOR = "aws.glue.catalog.separator";
 
     public static final String AWS_GLUE_DISABLE_UDF = "aws.glue.disable-udf";
+
+
+    public static final String AWS_GLUE_DB_CACHE_ENABLE = "aws.glue.cache.db.enable";
+    public static final String AWS_GLUE_DB_CACHE_SIZE = "aws.glue.cache.db.size";
+    public static final String AWS_GLUE_DB_CACHE_TTL_MINS = "aws.glue.cache.db.ttl-mins";
+
+    public static final String AWS_GLUE_TABLE_CACHE_ENABLE = "aws.glue.cache.table.enable";
+    public static final String AWS_GLUE_TABLE_CACHE_SIZE = "aws.glue.cache.table.size";
+    public static final String AWS_GLUE_TABLE_CACHE_TTL_MINS = "aws.glue.cache.table.ttl-mins";
 }

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecoratorTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecoratorTest.java
@@ -1,0 +1,178 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.Table;
+import com.google.common.cache.Cache;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_TTL_MINS;
+
+public class AWSGlueMetastoreCacheDecoratorTest {
+
+    private AWSGlueMetastore glueMetastore;
+    private HiveConf hiveConf;
+
+    private static final String DB_NAME = "db";
+    private static final String TABLE_NAME = "table";
+    private static final AWSGlueMetastoreCacheDecorator.TableIdentifier TABLE_IDENTIFIER =
+            new AWSGlueMetastoreCacheDecorator.TableIdentifier(DB_NAME, TABLE_NAME);
+
+    @Before
+    public void setUp() {
+        glueMetastore = mock(AWSGlueMetastore.class);
+        hiveConf = spy(new HiveConf());
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0)).thenReturn(100);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0)).thenReturn(100);
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0)).thenReturn(100);
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0)).thenReturn(100);
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorWithNullConf() {
+        new AWSGlueMetastoreCacheDecorator(null, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidTableCacheSize() {
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidTableCacheTtl() {
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidDbCacheSize() {
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidDbCacheTtl() {
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test
+    public void testGetDatabaseWhenCacheDisabled() {
+        //disable cache
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(false);
+        Database db = new Database();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        when(glueMetastore.getDatabase(DB_NAME)).thenReturn(db);
+        assertEquals(db, cacheDecorator.getDatabase(DB_NAME));
+        assertNull(cacheDecorator.databaseCache);
+        verify(glueMetastore, times(1)).getDatabase(DB_NAME);
+    }
+
+    @Test
+    public void testGetDatabaseWhenCacheEnabledAndCacheMiss() {
+        Database db = new Database();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.databaseCache);
+        Cache dbCache = mock(Cache.class);
+        cacheDecorator.databaseCache = dbCache;
+
+        when(dbCache.getIfPresent(DB_NAME)).thenReturn(null);
+        when(glueMetastore.getDatabase(DB_NAME)).thenReturn(db);
+        doNothing().when(dbCache).put(DB_NAME, db);
+
+        assertEquals(db, cacheDecorator.getDatabase(DB_NAME));
+
+        verify(glueMetastore, times(1)).getDatabase(DB_NAME);
+        verify(dbCache, times(1)).getIfPresent(DB_NAME);
+        verify(dbCache, times(1)).put(DB_NAME, db);
+    }
+
+    @Test
+    public void testGetDatabaseWhenCacheEnabledAndCacheHit() {
+        Database db = new Database();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.databaseCache);
+        Cache dbCache = mock(Cache.class);
+        cacheDecorator.databaseCache = dbCache;
+
+        when(dbCache.getIfPresent(DB_NAME)).thenReturn(db);
+
+        assertEquals(db, cacheDecorator.getDatabase(DB_NAME));
+
+        verify(dbCache, times(1)).getIfPresent(DB_NAME);
+    }
+
+    @Test
+    public void testGetTableWhenCacheDisabled() {
+        //disable cache
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(false);
+        Table table = new Table();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        when(glueMetastore.getTable(DB_NAME, TABLE_NAME)).thenReturn(table);
+        assertEquals(table, cacheDecorator.getTable(DB_NAME, TABLE_NAME));
+        assertNull(cacheDecorator.tableCache);
+        verify(glueMetastore, times(1)).getTable(DB_NAME, TABLE_NAME);
+    }
+
+    @Test
+    public void testGetTableWhenCacheEnabledAndCacheMiss() {
+        Table table = new Table();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.tableCache);
+        Cache tableCache = mock(Cache.class);
+        cacheDecorator.tableCache = tableCache;
+
+        when(tableCache.getIfPresent(TABLE_IDENTIFIER)).thenReturn(null);
+        when(glueMetastore.getTable(DB_NAME, TABLE_NAME)).thenReturn(table);
+        doNothing().when(tableCache).put(TABLE_IDENTIFIER, table);
+
+        assertEquals(table, cacheDecorator.getTable(DB_NAME, TABLE_NAME));
+
+        verify(glueMetastore, times(1)).getTable(DB_NAME, TABLE_NAME);
+        verify(tableCache, times(1)).getIfPresent(TABLE_IDENTIFIER);
+        verify(tableCache, times(1)).put(TABLE_IDENTIFIER, table);
+    }
+
+    @Test
+    public void testGetTableWhenCacheEnabledAndCacheHit() {
+        Table table = new Table();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.tableCache);
+        Cache tableCache = mock(Cache.class);
+        cacheDecorator.tableCache = tableCache;
+
+        when(tableCache.getIfPresent(TABLE_IDENTIFIER)).thenReturn(table);
+
+        assertEquals(table, cacheDecorator.getTable(DB_NAME, TABLE_NAME));
+
+        verify(tableCache, times(1)).getIfPresent(TABLE_IDENTIFIER);
+    }
+
+}

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactoryTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactoryTest.java
@@ -1,0 +1,84 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_ENDPOINT;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_REGION;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
+
+public class AWSGlueMetastoreFactoryTest {
+
+    private AWSGlueMetastoreFactory awsGlueMetastoreFactory;
+    private HiveConf hiveConf;
+
+    @Before
+    public void setUp() {
+        awsGlueMetastoreFactory = new AWSGlueMetastoreFactory();
+        hiveConf = spy(new HiveConf());
+
+        // these configs are needed for AWSGlueClient to get initialized
+        System.setProperty(AWS_REGION, "");
+        System.setProperty(AWS_GLUE_ENDPOINT, "");
+        when(hiveConf.get(AWS_GLUE_ENDPOINT)).thenReturn("endpoint");
+        when(hiveConf.get(AWS_REGION)).thenReturn("us-west-1");
+
+        // these configs are needed for AWSGlueMetastoreCacheDecorator to get initialized
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0)).thenReturn(1);
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0)).thenReturn(1);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0)).thenReturn(1);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0)).thenReturn(1);
+    }
+
+    @Test
+    public void testNewMetastoreWhenCacheDisabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(false);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(false);
+        assertTrue(DefaultAWSGlueMetastore.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+    @Test
+    public void testNewMetastoreWhenTableCacheEnabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(false);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        assertTrue(AWSGlueMetastoreCacheDecorator.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+    @Test
+    public void testNewMetastoreWhenDBCacheEnabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        assertTrue(AWSGlueMetastoreCacheDecorator.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+    @Test
+    public void testNewMetastoreWhenAllCacheEnabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        assertTrue(AWSGlueMetastoreCacheDecorator.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+}

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/BatchCreatePartitionsHelperTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/BatchCreatePartitionsHelperTest.java
@@ -1,6 +1,6 @@
 package com.amazonaws.glue.catalog.util;
 
-import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.glue.catalog.metastore.AWSGlueMetastore;
 import com.amazonaws.services.glue.model.AlreadyExistsException;
 import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
 import com.amazonaws.services.glue.model.BatchCreatePartitionResult;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 public class BatchCreatePartitionsHelperTest {
 
   @Mock
-  private AWSGlue client;
+  private AWSGlueMetastore awsGlueMetastore;
 
   private BatchCreatePartitionsHelper batchCreatePartitionsHelper;
 
@@ -56,7 +56,7 @@ public class BatchCreatePartitionsHelperTest {
     mockBatchCreateSuccess();
 
     List<Partition> partitions = Lists.newArrayList();
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
         .createPartitions();
 
     assertTrue(batchCreatePartitionsHelper.getPartitionsCreated().isEmpty());
@@ -72,7 +72,7 @@ public class BatchCreatePartitionsHelperTest {
     List<Partition> partitions = Lists.newArrayList(
         TestObjects.getTestPartition(NAMESPACE_NAME, TABLE_NAME, values1),
         TestObjects.getTestPartition(NAMESPACE_NAME, TABLE_NAME, values2));
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
         .createPartitions();
 
     assertEquals(2, batchCreatePartitionsHelper.getPartitionsCreated().size());
@@ -93,7 +93,7 @@ public class BatchCreatePartitionsHelperTest {
     List<Partition> partitions = Lists.newArrayList(
         TestObjects.getTestPartition(NAMESPACE_NAME, TABLE_NAME, values1),
         TestObjects.getTestPartition(NAMESPACE_NAME, TABLE_NAME, values2));
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, false);
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, false);
     batchCreatePartitionsHelper.createPartitions();
 
     assertNotNull(batchCreatePartitionsHelper.getFirstTException());
@@ -113,12 +113,12 @@ public class BatchCreatePartitionsHelperTest {
     Partition partition2 = TestObjects.getTestPartition(NAMESPACE_NAME, TABLE_NAME, values2);
     Partition partition3 = TestObjects.getTestPartition(NAMESPACE_NAME, TABLE_NAME, values3);
     List<Partition> partitions = Lists.newArrayList(partition1, partition2, partition3);
-    Mockito.when(client.getPartition(Mockito.any(GetPartitionRequest.class)))
-        .thenReturn(new GetPartitionResult().withPartition(partition1))
+    Mockito.when(awsGlueMetastore.getPartition(Mockito.anyString(), Mockito.anyString(), Mockito.anyList()))
+        .thenReturn(partition1)
         .thenThrow(new EntityNotFoundException("bar"))
         .thenThrow(new NullPointerException("baz"));
 
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
         .createPartitions();
 
     assertThat(batchCreatePartitionsHelper.getFirstTException(), is(instanceOf(MetaException.class)));
@@ -135,7 +135,7 @@ public class BatchCreatePartitionsHelperTest {
     List<String> values1 = Lists.newArrayList("val1");
     Partition partition = TestObjects.getTestPartition(NAMESPACE_NAME, TABLE_NAME, values1);
     List<Partition> partitions = Lists.newArrayList(partition, partition);
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
         .createPartitions();
 
     assertEquals(1, batchCreatePartitionsHelper.getPartitionsCreated().size());
@@ -157,7 +157,7 @@ public class BatchCreatePartitionsHelperTest {
     PartitionError error = getPartitionError(values1, new AlreadyExistsException("foo error msg"));
     mockBatchCreateWithFailures(Lists.newArrayList(error));
 
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, false)
         .createPartitions();
 
     assertEquals(1, batchCreatePartitionsHelper.getPartitionsCreated().size());
@@ -178,7 +178,7 @@ public class BatchCreatePartitionsHelperTest {
     PartitionError error = getPartitionError(values1, new AlreadyExistsException("foo error msg"));
     mockBatchCreateWithFailures(Lists.newArrayList(error));
 
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, true)
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, true)
         .createPartitions();
 
     assertEquals(1, batchCreatePartitionsHelper.getPartitionsCreated().size());
@@ -199,7 +199,7 @@ public class BatchCreatePartitionsHelperTest {
     PartitionError error2 = getPartitionError(values2, new AlreadyExistsException("foo error msg2"));
     mockBatchCreateWithFailures(Lists.newArrayList(error1, error2));
 
-    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(client, NAMESPACE_NAME, TABLE_NAME, null, partitions, true)
+    batchCreatePartitionsHelper = new BatchCreatePartitionsHelper(awsGlueMetastore, NAMESPACE_NAME, TABLE_NAME, null, partitions, true)
         .createPartitions();
 
     assertEquals(0, batchCreatePartitionsHelper.getPartitionsCreated().size());
@@ -209,17 +209,18 @@ public class BatchCreatePartitionsHelperTest {
   }
 
   private void mockBatchCreateSuccess() {
-    Mockito.when(client.batchCreatePartition(Mockito.any(BatchCreatePartitionRequest.class)))
-        .thenReturn(new BatchCreatePartitionResult());
+    Mockito.when(awsGlueMetastore.createPartitions(Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyList())).thenReturn(null);
   }
 
-  private void mockBatchCreateWithFailures(Collection<PartitionError> errors) {
-    Mockito.when(client.batchCreatePartition(Mockito.any(BatchCreatePartitionRequest.class)))
-        .thenReturn(new BatchCreatePartitionResult().withErrors(errors));
+  private void mockBatchCreateWithFailures(List<PartitionError> errors) {
+    Mockito.when(awsGlueMetastore.createPartitions(Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyList())).thenReturn(errors);
   }
 
   private void mockBatchCreateThrowsException(Exception e) {
-    Mockito.when(client.batchCreatePartition(Mockito.any(BatchCreatePartitionRequest.class))).thenThrow(e);
+    Mockito.when(awsGlueMetastore.createPartitions(Mockito.anyString(), Mockito.anyString(),
+            Mockito.anyList())).thenThrow(e);
   }
 
 }

--- a/aws-glue-datacatalog-hive3-client/src/test/java/com/amazonaws/glue/catalog/metastore/HiveAWSCatalogMetastoreClientTest.java
+++ b/aws-glue-datacatalog-hive3-client/src/test/java/com/amazonaws/glue/catalog/metastore/HiveAWSCatalogMetastoreClientTest.java
@@ -3,14 +3,10 @@ package com.amazonaws.glue.catalog.metastore;
 import com.amazonaws.glue.catalog.converters.CatalogToHiveConverter;
 import com.amazonaws.glue.catalog.converters.Hive3CatalogToHiveConverter;
 import com.amazonaws.services.glue.AWSGlue;
-import com.amazonaws.services.glue.model.GetDatabasesRequest;
-import com.amazonaws.services.glue.model.GetUserDefinedFunctionsRequest;
-import com.amazonaws.services.glue.model.GetUserDefinedFunctionsResult;
 import com.amazonaws.services.glue.model.UserDefinedFunction;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.ForeignKeysRequest;
-import org.apache.hadoop.hive.metastore.api.GetAllFunctionsResponse;
 import org.apache.hadoop.hive.metastore.api.PrimaryKeysRequest;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.junit.Before;
@@ -20,12 +16,8 @@ import static com.amazonaws.glue.catalog.util.TestObjects.getCatalogTestFunction
 import static com.amazonaws.glue.catalog.util.TestObjects.getTestDatabase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HiveAWSCatalogMetastoreClientTest {
@@ -56,20 +48,6 @@ public class HiveAWSCatalogMetastoreClientTest {
     when(clientFactory.newClient()).thenReturn(glueClient);
     metastoreClient = new AWSCatalogMetastoreClient.Builder().withClientFactory(clientFactory)
         .createDefaults(false).withConf(conf).withCatalogId(catalogId).build();
-  }
-
-  @Test
-  public void testGetAllFunctions() throws Exception {
-    when(glueClient.getUserDefinedFunctions(any(GetUserDefinedFunctionsRequest.class)))
-        .thenReturn(new GetUserDefinedFunctionsResult().withUserDefinedFunctions(catalogTestFunction)
-            .withNextToken("nexttoken"))
-        .thenReturn(new GetUserDefinedFunctionsResult().withUserDefinedFunctions(catalogTestFunction));
-
-    GetAllFunctionsResponse getAllFunctionsResponse = metastoreClient.getAllFunctions();
-    verify(glueClient, never()).getDatabases(any(GetDatabasesRequest.class));
-    verify(glueClient, times(2)).getUserDefinedFunctions(any(GetUserDefinedFunctionsRequest.class));
-    assertEquals(2, getAllFunctionsResponse.getFunctionsSize());
-    assertEquals(testFunction, getAllFunctionsResponse.getFunctions().get(0));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <guava.version>14.0</guava.version>
+    <guava.version>28.2-jre</guava.version>
     <hive3.version>3.1.3</hive3.version>
     <spark-hive.version>2.3.10-SNAPSHOT</spark-hive.version>
     <aws.sdk.version>1.12.31</aws.sdk.version>


### PR DESCRIPTION
We have factored out a new interface(AWSGlueMetastore) between GlueMetastoreClientDelegate and AWSGlue, and the cache is implemented over this new interface. For both GetTable and GetDatabase, we have separate instances of caches which can be enabled/tuned separately. Please refer to the 'Enabling client side caching for catalog' section in the README file for more details.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.