### PR TITLE
Set catalogId before interacting with the default database

### DIFF
--- a/aws-glue-datacatalog-hive3-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-hive3-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -172,6 +172,7 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
 
   public AWSCatalogMetastoreClient(Configuration conf, HiveMetaHookLoader hook) throws MetaException {
     this.conf = conf;
+    catalogId = MetastoreClientUtils.getCatalogId(conf);
     glueClient = new AWSGlueClientFactory(this.conf).newClient();
     catalogToHiveConverter = new Hive3CatalogToHiveConverter();
 
@@ -185,7 +186,6 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
     if (!doesDefaultDBExist()) {
       createDefaultDatabase();
     }
-    catalogId = MetastoreClientUtils.getCatalogId(conf);
   }
 
   /**

--- a/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -135,6 +135,7 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
 
   public AWSCatalogMetastoreClient(HiveConf conf, HiveMetaHookLoader hook) throws MetaException {
     this.conf = conf;
+    catalogId = MetastoreClientUtils.getCatalogId(conf);
     glueClient = new AWSGlueClientFactory(this.conf).newClient();
     catalogToHiveConverter = new BaseCatalogToHiveConverter();
 
@@ -148,7 +149,6 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
     if (!doesDefaultDBExist()) {
       createDefaultDatabase();
     }
-    catalogId = MetastoreClientUtils.getCatalogId(conf);
   }
 
   /**


### PR DESCRIPTION
Issue #: #68

Description of changes:
Sets the catalogId instance variable before calling into `doesDefaultDBExist()`, which references this same instance variable. In the previous behavior, the `doesDefaultDBExist()` check would reference the catalog ID associated to the account the IAM identity doing the call is a part of. Now it will appropriately use the catalog ID the client was configured with.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.