### PR TITLE
fix hcatalog writing to glue tables

### DIFF
--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegate.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegate.java
@@ -1261,7 +1261,7 @@ public class GlueMetastoreClientDelegate {
   }
 
   public String getTokenStrForm() throws IOException {
-    throw new UnsupportedOperationException("getTokenStrForm is not supported");
+    return null;
   }
 
   public boolean addToken(String tokenIdentifier, String delegationToken) throws TException {


### PR DESCRIPTION
fixes the issue described in: https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/issues/37