### PR TITLE
Use a custom executor service if config is set

### DIFF
--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
@@ -57,7 +57,6 @@ import com.amazonaws.services.glue.model.UserDefinedFunction;
 import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -73,7 +72,6 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -110,14 +108,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
      */
     public static final String SKIP_AWS_GLUE_ARCHIVE = "skipAWSGlueArchive";
 
-    private static final int NUM_EXECUTOR_THREADS = 5;
     static final String GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT = "glue-metastore-delegate-%d";
-    private static final ExecutorService GLUE_METASTORE_DELEGATE_THREAD_POOL = Executors.newFixedThreadPool(
-            NUM_EXECUTOR_THREADS,
-            new ThreadFactoryBuilder()
-                    .setNameFormat(GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT)
-                    .setDaemon(true).build()
-    );
 
     private final Configuration conf;
     private final AWSGlue glueClient;
@@ -508,7 +499,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                         .withTableName(tableName)
                         .withPartitionValues(partValues)
                         .withColumnNames(cols);
-                pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<GetColumnStatisticsForPartitionResult>() {
+                pagedResult.add(this.executorService.submit(new Callable<GetColumnStatisticsForPartitionResult>() {
                     @Override
                     public GetColumnStatisticsForPartitionResult call() throws Exception {
                         return glueClient.getColumnStatisticsForPartition(request);
@@ -543,7 +534,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                     .withDatabaseName(dbName)
                     .withTableName(tableName)
                     .withColumnNames(cols);
-            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<GetColumnStatisticsForTableResult>() {
+            pagedResult.add(this.executorService.submit(new Callable<GetColumnStatisticsForTableResult>() {
                 @Override
                 public GetColumnStatisticsForTableResult call() throws Exception {
                     return glueClient.getColumnStatisticsForTable(request);
@@ -581,7 +572,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                     .withTableName(tableName)
                     .withPartitionValues(partitionValues)
                     .withColumnStatisticsList(statList);
-            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<UpdateColumnStatisticsForPartitionResult>() {
+            pagedResult.add(this.executorService.submit(new Callable<UpdateColumnStatisticsForPartitionResult>() {
                 @Override
                 public UpdateColumnStatisticsForPartitionResult call() throws Exception {
                     return glueClient.updateColumnStatisticsForPartition(request);
@@ -617,7 +608,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                     .withDatabaseName(dbName)
                     .withTableName(tableName)
                     .withColumnStatisticsList(statList);
-            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<UpdateColumnStatisticsForTableResult>() {
+            pagedResult.add(this.executorService.submit(new Callable<UpdateColumnStatisticsForTableResult>() {
                 @Override
                 public UpdateColumnStatisticsForTableResult call() throws Exception {
                     return glueClient.updateColumnStatisticsForTable(request);

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
@@ -7,6 +7,7 @@ import com.amazonaws.glue.catalog.converters.CatalogToHiveConverterFactory;
 import com.amazonaws.glue.catalog.converters.GlueInputConverter;
 import com.amazonaws.glue.catalog.converters.HiveToCatalogConverter;
 import com.amazonaws.glue.catalog.util.TestObjects;
+import com.amazonaws.glue.catalog.util.TestExecutorServiceFactory;
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.AlreadyExistsException;
 import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
@@ -173,6 +174,21 @@ public class GlueMetastoreClientDelegateTest {
     when(wh.getDnsPath(path)).thenReturn(path);
     when(wh.isDir(path)).thenReturn(isDir);
     when(wh.mkdirs(path)).thenReturn(mkDir);
+  }
+
+  // ===================== Thread Executor =====================
+
+  @Test
+  public void testExecutorService() throws Exception {
+    Object defaultExecutorService = new DefaultExecutorServiceFactory().getExecutorService(conf);
+    assertEquals("Default executor service should be used", metastoreClientDelegate.getExecutorService(), defaultExecutorService);
+    HiveConf customConf = new HiveConf();
+    customConf.set(GlueMetastoreClientDelegate.CATALOG_ID_CONF, CATALOG_ID);
+    customConf.setClass(GlueMetastoreClientDelegate.CUSTOM_EXECUTOR_FACTORY_CONF, TestExecutorServiceFactory.class, ExecutorServiceFactory.class);
+    GlueMetastoreClientDelegate customDelegate = new GlueMetastoreClientDelegate(customConf, mock(AWSGlue.class), mock(Warehouse.class));
+    Object customExecutorService = new TestExecutorServiceFactory().getExecutorService(customConf);
+
+    assertEquals("Custom executor service should be used", customDelegate.getExecutorService(), customExecutorService);
   }
 
   // ===================== Database =====================

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
@@ -182,6 +182,7 @@ public class GlueMetastoreClientDelegateTest {
   public void testExecutorService() throws Exception {
     Object defaultExecutorService = new DefaultExecutorServiceFactory().getExecutorService(conf);
     assertEquals("Default executor service should be used", metastoreClientDelegate.getExecutorService(), defaultExecutorService);
+    assertEquals("Default executor service should be used", (new DefaultAWSGlueMetastore(conf, glueClient)).getExecutorService(), defaultExecutorService);
     HiveConf customConf = new HiveConf();
     customConf.set(GlueMetastoreClientDelegate.CATALOG_ID_CONF, CATALOG_ID);
     customConf.setClass(GlueMetastoreClientDelegate.CUSTOM_EXECUTOR_FACTORY_CONF, TestExecutorServiceFactory.class, ExecutorServiceFactory.class);
@@ -189,6 +190,7 @@ public class GlueMetastoreClientDelegateTest {
     Object customExecutorService = new TestExecutorServiceFactory().getExecutorService(customConf);
 
     assertEquals("Custom executor service should be used", customDelegate.getExecutorService(), customExecutorService);
+    assertEquals("Default executor service should be used", (new DefaultAWSGlueMetastore(customConf, glueClient)).getExecutorService(), customExecutorService);
   }
 
   // ===================== Database =====================

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorService.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorService.java
@@ -1,0 +1,11 @@
+package com.amazonaws.glue.catalog.util;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+
+public class TestExecutorService extends ScheduledThreadPoolExecutor {
+
+    public TestExecutorService(int corePoolSize, ThreadFactory factory) {
+        super(corePoolSize, factory);
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorServiceFactory.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorServiceFactory.java
@@ -1,0 +1,16 @@
+package com.amazonaws.glue.catalog.util;
+
+import com.amazonaws.glue.catalog.metastore.ExecutorServiceFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+import java.util.concurrent.ExecutorService;
+
+public class TestExecutorServiceFactory implements ExecutorServiceFactory {
+    private static ExecutorService execService = new TestExecutorService(1, new ThreadFactoryBuilder().build());
+
+    @Override
+    public ExecutorService getExecutorService(HiveConf conf) {
+        return execService;
+    }
+}

--- a/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -112,7 +112,6 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
   // TODO "hook" into Hive logging (hive or hive.metastore)
   private static final Logger logger = Logger.getLogger(AWSCatalogMetastoreClient.class);
 
-  private final ExecutorService executorService;
   private final HiveConf conf;
   private final AWSGlue glueClient;
   private final Warehouse wh;


### PR DESCRIPTION
This PR is a cherry-pick and enhancement of the original PR submitted by Databricks. https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/pull/11

The original PR explains the intention pretty well:

> Created a new interface ExecutorServiceFactory and a default implementation of it that maintains existing behavior.
Introduced a new config hive.metastore.executorservice.factory.class that will be used by Databricks to provide a custom executor service factory that returns a custom ExecutorService.

The first commit of the change is a pure cherry-pick. https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/pull/73/commits/2352c78c844e392dc08d76b2c5f1635d81e6180e

The second commit is an enhancement horizontally. As we found out there were quite some other thread pools used in the glue client that didn't support configuration executor service.

The third commit is an optimization to ask all those instances to share the configurable executor services just as they did before the executor service became configurable.

I do have tests in this PR but I cannot really compile locally so I do not really test this out in UT tests yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
