### PR TITLE
Race condition in AWSCatalogMetastoreClient: isCompatibleWith and close

### DIFF
--- a/aws-glue-datacatalog-hive3-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-hive3-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -1464,13 +1464,16 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
 
   @Override
   public boolean isCompatibleWith(Configuration conf) {
-    if (currentMetaVars == null) {
+    // Make a copy of currentMetaVars, there is a race condition that
+    // currentMetaVars might be changed during the execution of the method
+    Map<String, String> currentMetaVarsCopy = currentMetaVars;
+    if (currentMetaVarsCopy == null) {
       return false; // recreate
     }
     boolean compatible = true;
     for (MetastoreConf.ConfVars oneVar : MetastoreConf.metaVars) {
       // Since metaVars are all of different types, use string for comparison
-      String oldVar = currentMetaVars.get(oneVar.getVarname());
+      String oldVar = currentMetaVarsCopy.get(oneVar.getVarname());
       String newVar = conf.get(oneVar.getVarname(), "");
       if (oldVar == null ||
             (oneVar.isCaseSensitive() ? !oldVar.equals(newVar) : !oldVar.equalsIgnoreCase(newVar))) {

--- a/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -1089,13 +1089,16 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
 
   @Override
   public boolean isCompatibleWith(HiveConf conf) {
-      if (currentMetaVars == null) {
+    // Make a copy of currentMetaVars, there is a race condition that
+    // currentMetaVars might be changed during the execution of the method
+    Map<String, String> currentMetaVarsCopy = currentMetaVars;
+    if (currentMetaVarsCopy == null) {
           return false; // recreate
       }
       boolean compatible = true;
       for (ConfVars oneVar : HiveConf.metaVars) {
           // Since metaVars are all of different types, use string for comparison
-          String oldVar = currentMetaVars.get(oneVar.varname);
+          String oldVar = currentMetaVarsCopy.get(oneVar.varname);
           String newVar = conf.get(oneVar.varname, "");
           if (oldVar == null ||
                 (oneVar.isCaseSensitive() ? !oldVar.equals(newVar) : !oldVar.equalsIgnoreCase(newVar))) {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/issues/79

*Description of changes:* There is an intermittent NullPointerException from AWSCatalogMetastoreClient. This issue stems from a race condition in the `AWSCatalogMetastoreClient` (specifically the `isCompatibleWith` and `close` methods)
Apache Hive metastore already handled such race condition [HIVE-11935](https://issues.apache.org/jira/browse/HIVE-11935)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
